### PR TITLE
fix: 디퍼 홈 화면 다음 세션 조회 수정

### DIFF
--- a/apps/client/app/(auth)/(home)/_components/session-card.tsx
+++ b/apps/client/app/(auth)/(home)/_components/session-card.tsx
@@ -1,7 +1,5 @@
 'use client';
 
-import Link from 'next/link';
-
 interface SessionCardProps {
 	subtitle: string;
 	title: string;
@@ -19,8 +17,7 @@ const SessionCard = ({ subtitle, title, startTimeInfo, place, id }: SessionCardP
 		: {};
 
 	return (
-		<Link
-			href="/session-detail"
+		<div
 			className="bg-background-subtle flex flex-col rounded-lg p-5 animate-view-transition cursor-pointer hover:bg-background-strong transition-colors"
 			style={cardStyle}
 		>
@@ -49,7 +46,7 @@ const SessionCard = ({ subtitle, title, startTimeInfo, place, id }: SessionCardP
 					<span className="inline-flex text-body2 text-label-subtle font-medium">{place}</span>
 				</div>
 			</div>
-		</Link>
+		</div>
 	);
 };
 

--- a/apps/client/app/(auth)/(home)/_components/session-card.tsx
+++ b/apps/client/app/(auth)/(home)/_components/session-card.tsx
@@ -6,11 +6,11 @@ interface SessionCardProps {
 	subtitle: string;
 	title: string;
 	startTimeInfo: string;
-	endTimeInfo: string;
+	place: string;
 	id?: string; // 고유 ID 추가
 }
 
-const SessionCard = ({ subtitle, title, startTimeInfo, endTimeInfo, id }: SessionCardProps) => {
+const SessionCard = ({ subtitle, title, startTimeInfo, place, id }: SessionCardProps) => {
 	// 고유한 view-transition-name을 위한 스타일
 	const cardStyle = id
 		? {
@@ -40,11 +40,13 @@ const SessionCard = ({ subtitle, title, startTimeInfo, endTimeInfo, id }: Sessio
 			<div className="gap-y-3 flex flex-col">
 				<div className="gap-x-4 flex">
 					<span className="text-body2 font-semibold text-label-assistive w-[70px]">세션 시간</span>
-					<span className="inline-flex text-body2 text-label-subtle">{startTimeInfo}</span>
+					<span className="inline-flex text-body2 text-label-subtle font-medium">
+						{startTimeInfo}
+					</span>
 				</div>
 				<div className="gap-x-4 flex">
 					<span className="text-body2 font-semibold text-label-assistive w-[70px]">세션 장소</span>
-					<span className="inline-flex text-body2 text-label-subtle">{endTimeInfo}</span>
+					<span className="inline-flex text-body2 text-label-subtle font-medium">{place}</span>
 				</div>
 			</div>
 		</Link>

--- a/apps/client/app/(auth)/(home)/_components/session-list.tsx
+++ b/apps/client/app/(auth)/(home)/_components/session-list.tsx
@@ -6,26 +6,25 @@ import { useSuspenseQuery } from '@tanstack/react-query';
 import { Suspense } from 'react';
 import { Loading } from '@/components/lotties/loading';
 import { formatISOStringToFullDateString } from '@/lib/date';
-import { getSessionListQuery } from '@/remotes/queries/session';
+import { getSessionCurrentOptions } from '@/remotes/queries/session';
 import { SessionCard } from './session-card';
 
 const SessionListContainer = () => {
 	const {
-		data: { data },
-	} = useSuspenseQuery(getSessionListQuery);
+		data: { data: currentWeekSession },
+	} = useSuspenseQuery(getSessionCurrentOptions());
+
 	return (
 		<>
-			{data.sessions?.length ? (
+			{currentWeekSession ? (
 				<div className="my-5 px-4 flex-1">
-					{data.sessions.map((session) => (
-						<SessionCard
-							key={session.id}
-							subtitle={`${session.week}주차 세션`}
-							title={session.eventName}
-							startTimeInfo={formatISOStringToFullDateString(session.date)}
-							endTimeInfo={formatISOStringToFullDateString(session.date)}
-						/>
-					))}
+					<SessionCard
+						id={currentWeekSession.sessionId.toString()}
+						subtitle={`${currentWeekSession.week}주차 세션`}
+						title={currentWeekSession.eventName}
+						startTimeInfo={formatISOStringToFullDateString(currentWeekSession.date)}
+						place={currentWeekSession.isOnline ? '온라인' : currentWeekSession.place}
+					/>
 				</div>
 			) : (
 				<div className="flex flex-col items-center justify-center gap-y-3 flex-1">

--- a/apps/client/remotes/queries/session.ts
+++ b/apps/client/remotes/queries/session.ts
@@ -1,10 +1,19 @@
 import { session } from '@dpm-core/api';
+
 import { queryOptions } from '@tanstack/react-query';
 
 export const getSessionListQuery = queryOptions({
 	queryKey: ['session-list'],
 	queryFn: session.getList,
 });
+
+export const getSessionCurrentOptions = () =>
+	queryOptions({
+		queryKey: ['session-current-week'],
+		queryFn: async () => {
+			return session.getCurrentWeekSession();
+		},
+	});
 
 export const getSessionAttendanceTimeOptions = (sessionId: number) =>
 	queryOptions({


### PR DESCRIPTION
## 🚀 작업 개요

<!-- 이번 PR의 목적과 해결하려는 문제를 간단히 설명 -->

## 🚀 작업 개요

Home 화면의 세션 정보 API 및 UI 개선  
세션 카드의 Link 제거 및 데이터 구조 변경 반영

---

## ✨ 주요 변경사항

### 1. Home 화면 세션 API 변경 🛠️
- **설명**: 기존 세션 리스트 API에서 현재 주차 세션 단일 데이터로 변경
- **주요 내용**:
  - `getSessionListQuery` → `getSessionCurrentOptions`로 쿼리 변경
  - 세션 데이터 구조 변경에 따라 props 및 렌더링 방식 수정

### 2. 세션 카드 UI 및 Link 제거 🖱️
- **설명**: 세션 카드에서 next/link 제거 및 div로 대체
- **주요 내용**:
  - 세션 카드 클릭 시 Link 대신 div로 감싸도록 변경
  - 스타일 및 view-transition 유지

---

## 🔧 기술적 개선사항

### 세션 카드 컴포넌트 변경
```typescript
// 변경 전
import Link from 'next/link';
// ...
return (
  <Link href="/session-detail" ...>
    {/* ... */}
  </Link>
);

// 변경 후
// import Link 제거
return (
  <div ...>
    {/* ... */}
  </div>
);

// 변경 전
const { data: { data } } = useSuspenseQuery(getSessionListQuery);
// ...data.sessions.map...

// 변경 후
const { data: { data: currentWeekSession } } = useSuspenseQuery(getSessionCurrentOptions());
// ...<SessionCard ... currentWeekSession ... />
