### PR TITLE
CI / CD Workflow 재구축

### DIFF
--- a/.github/workflows/deploy-dispatch.yml
+++ b/.github/workflows/deploy-dispatch.yml
@@ -1,18 +1,14 @@
-name: Deploy Workflow Dispatch
+name: Deploy App with Vercel
 
 on:
   workflow_dispatch:
     inputs:
-      user_name:
-        description: 배포한 사용자
-        required: true
-        type: string
       stage_choice:
         description: 배포 유형
         type: choice
         options:
           - production
-          - develop
+          - preview
       app:
         description: 배포할 앱
         required: true
@@ -22,17 +18,12 @@ on:
           - client
           - all
 
-run-name: '${{inputs.user_name}} runs workflow for ${{inputs.stage_choice}} deploy ${{inputs.app}}'
+run-name: '${{ inputs.stage_choice }}: ${{ github.actor }} runs workflow to deploy ${{ inputs.app }}'
 
 jobs:
   deploy:
     uses: './.github/workflows/deploy-vercel.yml'
     with:
-      user_name: ${{ inputs.user_name }}
       stage: ${{ inputs.stage_choice }}
-      app: ${{ inputs.app }}
-    secrets:
-      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
-      VERCEL_PROJECT_ID_ADMIN: ${{ secrets.VERCEL_PROJECT_ID_ADMIN }}
-      VERCEL_PROJECT_ID_CLIENT: ${{ secrets.VERCEL_PROJECT_ID_CLIENT }}
-      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      app: ${{ inputs.app == 'all' && '["admin","client"]' || format('["{0}"]', inputs.app) }}
+    secrets: inherit

--- a/.github/workflows/deploy-vercel.yml
+++ b/.github/workflows/deploy-vercel.yml
@@ -3,9 +3,6 @@ name: Deploy Vercel
 on:
   workflow_call:
     inputs:
-      user_name:
-        required: true
-        type: string
       stage:
         required: true
         type: string
@@ -26,58 +23,53 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
-        include:
-          - name: admin
-            path: apps/admin
-            project_env: VERCEL_PROJECT_ID_ADMIN
-          - name: client
-            path: apps/client
-            project_env: VERCEL_PROJECT_ID_CLIENT
+        app: ${{ fromJSON(inputs.app) }}
+
+    env:
+      VERCEL_PROJECT_ID: ${{ secrets[matrix.app == 'admin' && 'VERCEL_PROJECT_ID_ADMIN' || 'VERCEL_PROJECT_ID_CLIENT'] }}
+      VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
     steps:
-      - name: Checkout repository
+      - name: Checkout repository 
         uses: actions/checkout@v4
 
-      - name: Setup Node.js and PNPM
-        run: |
-          corepack enable
-          corepack prepare pnpm@8 --activate
-        shell: bash
-        env:
-          NODE_VERSION: 22
+      - name: Setup pnpm environment
+        uses: pnpm/action-setup@v4
+        with:
+          run_install: false
 
-      - name: Install dependencies
+      - name: Setup node environment
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22.x 
+          cache: 'pnpm'
+
+      - name: Install Dependencies
         run: pnpm install --frozen-lockfile
 
       - name: Pull Vercel Environment
-        run: vercel pull --yes --token=$VERCEL_TOKEN --cwd ${{ matrix.path }}
-        env:
-          VERCEL_PROJECT_ID: ${{ secrets[matrix.project_env] }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+        run: pnpm dlx vercel@latest pull --yes --environment=${{ inputs.stage }} --token=$VERCEL_TOKEN
 
-      - name: Build Project
-        run: vercel build --token=$VERCEL_TOKEN --cwd ${{ matrix.path }}
-        env:
-          VERCEL_PROJECT_ID: ${{ secrets[matrix.project_env] }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+      - name: Build
+        run: |
+          if [ "${{ inputs.stage }}" = "production" ]; then
+            pnpm dlx vercel@latest build --token=$VERCEL_TOKEN --prod
+          else
+            pnpm dlx vercel@latest build --token=$VERCEL_TOKEN
+          fi
 
-      - name: Deploy Prebuilt to Vercel
-        if: ${{ inputs.app == matrix.name || inputs.app == 'all' }}
+      - name: Deploy
         run: |
           if [ "${{ inputs.stage }}" = "production" ]; then
             if [ "$GITHUB_REF" = "refs/heads/main" ]; then
-              vercel deploy --prebuilt --prod --token=$VERCEL_TOKEN --cwd ${{ matrix.path }}
+              pnpm dlx vercel@latest deploy --prebuilt --prod --token=$VERCEL_TOKEN
             else
               echo "Production 배포는 main 브랜치에서만 가능합니다."
               exit 1
             fi
           else
-            vercel deploy --prebuilt --token=$VERCEL_TOKEN --cwd ${{ matrix.path }}
+            pnpm dlx vercel@latest deploy --prebuilt --token=$VERCEL_TOKEN
           fi
-        env:
-          VERCEL_PROJECT_ID: ${{ secrets[matrix.project_env] }}
-          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}


### PR DESCRIPTION
## 📌 개요
기존 Vercel Git 자동 배포 전략을 제거하고 CLI를 통해서 수동적인 배포 방식으로 변경하였습니다.

## 📋 변경사항
- workflow_dispatch를 통해서 수동적으로 admin, client 를 선택하여 배포가 가능합니다.
- main 브랜치가 아닌 Production 환경으로 배포를 진행하는 경우 배포를 못하도록 방지하였습니다.
> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

### ⏰ 리뷰 희망 기한