### PR TITLE
[develop] 토스트 가운데 정렬 QA

### DIFF
--- a/apps/admin/app/layout.tsx
+++ b/apps/admin/app/layout.tsx
@@ -45,7 +45,10 @@ export default function RootLayout({
 					<Toaster
 						position="top-center"
 						visibleToasts={1}
-						style={{ pointerEvents: 'none' }}
+						style={{
+							display: 'flex',
+							justifyContent: 'center',
+						}}
 						toastOptions={{
 							duration: 3_000,
 						}}

--- a/apps/client/app/layout.tsx
+++ b/apps/client/app/layout.tsx
@@ -1,3 +1,6 @@
+import type { Metadata, Viewport } from 'next';
+import Script from 'next/script';
+import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
 import {
 	AppShell,
 	GAInitializer,
@@ -5,9 +8,6 @@ import {
 	getGAScriptSrc,
 	Toaster,
 } from '@dpm-core/shared';
-import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import type { Metadata, Viewport } from 'next';
-import Script from 'next/script';
 
 import { QueryProvider } from '../providers/query-provider';
 import { pretendard } from './fonts';
@@ -50,7 +50,10 @@ export default function RootLayout({
 					<Toaster
 						position="top-center"
 						visibleToasts={1}
-						style={{ pointerEvents: 'none' }}
+						style={{
+							display: 'flex',
+							justifyContent: 'center',
+						}}
 						toastOptions={{
 							duration: 3_000,
 						}}


### PR DESCRIPTION
## 📌 개요
출석코드 토스트메시지가 pc, 모바일 둘다 세션 살짝 좌측에서 뜨는 경우를 수정하였습니다.
토스트메시지 위치를 가운데 정렬하였습니다.

> 참고 링크
[QA  참고 노션](https://www.notion.so/depromeet/2a045b4338b380cc8ff5f5cab9b196f6?source=copy_link)

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

