### PR TITLE
[main] 로딩 로티 사이즈 가이드 적용

### DIFF
--- a/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/_components/search-input.tsx
+++ b/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/_components/search-input.tsx
@@ -20,7 +20,7 @@ export const SearchInput = ({ className, ...props }: React.ComponentProps<'input
 		<div className="relative">
 			<Input
 				className={cn(
-					'pr-11.5 placeholder:font-normal md:h-10 md:border md:border-line-normal md:bg-white md:px-4',
+					'pr-11.5 placeholder:font-normal md:h-10 md:border md:border-line-normal md:bg-white',
 					className,
 				)}
 				defaultValue={nameValue}

--- a/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/people/_components/attendance-member-container.tsx
+++ b/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/people/_components/attendance-member-container.tsx
@@ -42,11 +42,7 @@ const AttendanceMemberContainer = () => {
 
 	// 초기 로딩만 전체 LoadingBox 표시
 	if (isLoading && !data) {
-		return (
-			<div className="mx-auto flex h-[212px] w-[375px] flex-1 flex-col">
-				<LoadingBox />
-			</div>
-		);
+		return <LoadingBox />;
 	}
 
 	return (

--- a/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/session/_components/attendance-session-container.tsx
+++ b/apps/admin/app/(auth)/(attendance)/attendance/search/@tabs/session/_components/attendance-session-container.tsx
@@ -91,11 +91,7 @@ const AttendanceSessionContainer = () => {
 
 	// 초기 로딩만 전체 LoadingBox 표시
 	if (isLoading && !attendanceData) {
-		return (
-			<div className="mx-auto flex h-[212px] w-[375px] flex-1 flex-col">
-				<LoadingBox />
-			</div>
-		);
+		return <LoadingBox />;
 	}
 
 	return (

--- a/apps/admin/app/(auth)/(home)/_components/attendance-list.tsx
+++ b/apps/admin/app/(auth)/(home)/_components/attendance-list.tsx
@@ -96,7 +96,7 @@ export const TableProfile = (props: TableProfileProps) => {
 
 	return (
 		<figure className="flex items-center gap-3">
-			<div className="flex-shrink-0 overflow-hidden rounded-full bg-background-strong">
+			<div className="shrink-0 overflow-hidden rounded-full bg-background-strong">
 				<Image
 					width={size}
 					height={size}

--- a/apps/admin/app/(auth)/(home)/_components/current-week-session.tsx
+++ b/apps/admin/app/(auth)/(home)/_components/current-week-session.tsx
@@ -6,7 +6,7 @@ import { ErrorBoundary } from '@suspensive/react';
 import { useSuspenseQuery } from '@tanstack/react-query';
 import { Aesterisk, Button, ChevronRight, gaTrackHomeEnter } from '@dpm-core/shared';
 
-import { Loading } from '@/components/lotties/loading';
+import { LoadingBox } from '@/components/loading-box';
 import { formatISOStringToFullDateString } from '@/lib/date';
 import { getCurrentWeekSessionQuery } from '@/remotes/queries/session';
 
@@ -94,7 +94,7 @@ const CurrentWeekSession = () => (
 			</div>
 		)}
 	>
-		<Suspense fallback={<Loading />}>
+		<Suspense fallback={<LoadingBox />}>
 			<CurrentWeekSessionContainer />
 		</Suspense>
 	</ErrorBoundary>

--- a/apps/admin/app/(auth)/(home)/_components/home-attendance.tsx
+++ b/apps/admin/app/(auth)/(home)/_components/home-attendance.tsx
@@ -43,10 +43,9 @@ export const HomeAttendance = () => {
 		<Section>
 			<AttendanceHeader session={prevSession} />
 			<div className="flex justify-between">
-				<SearchInput
-					placeholder="디퍼 검색"
-					className="h-10 w-[270px] min-w-0 shrink-1 border border-line-normal bg-background-normal px-4 py-2.5 max-[800px]:w-[240px]"
-				/>
+				<div className="max-w-[270px] flex-1">
+					<SearchInput id="search" placeholder="디퍼 검색" />
+				</div>
 				<AttendanceFilter />
 			</div>
 

--- a/apps/admin/app/(auth)/(home)/_components/session-banner.tsx
+++ b/apps/admin/app/(auth)/(home)/_components/session-banner.tsx
@@ -94,7 +94,7 @@ const AttendanceCodeBanner = (props: AttendanceBannerProps) => {
 					</span>
 					<strong className="md:font-bold md:text-headline2">{attendanceCode}</strong>
 				</p>
-				<div className="absolute right-5 bottom-5 rounded-full bg-blue-300 p-[10px] max-md:hidden">
+				<div className="absolute right-5 bottom-5 rounded-full bg-blue-300 p-2.5 max-md:hidden">
 					<ArrowRight />
 				</div>
 				<ChevronRight className="text-white md:hidden" />
@@ -153,7 +153,7 @@ const CurrentSessionBanner = (props: CurrentSessionBannerProps) => {
 					</Link>
 				</Button>
 			</div>
-			<div className="absolute right-5 bottom-5 rounded-full bg-blue-400 p-[10px] max-md:hidden">
+			<div className="absolute right-5 bottom-5 rounded-full bg-blue-400 p-2.5 max-md:hidden">
 				<ArrowRight />
 			</div>
 		</div>

--- a/apps/admin/app/(auth)/(split-session)/session/@detail/_components/SessionDetailInfo.tsx
+++ b/apps/admin/app/(auth)/(split-session)/session/@detail/_components/SessionDetailInfo.tsx
@@ -11,6 +11,7 @@ import {
 } from '@dpm-core/shared';
 
 import { ErrorBox } from '@/components/error-box';
+import { LoadingBox } from '@/components/loading-box';
 import { formatISOStringHHMM, formatISOStringToFullDateString } from '@/lib/date';
 import { getSessionDetailQuery } from '@/remotes/queries/session';
 
@@ -104,7 +105,7 @@ const SessionDetailInfoBox = ({
 export const SessionDetailInfo = ({ sessionId }: SessionDetailInfoProps) => {
 	return (
 		<ErrorBoundary fallback={(props) => <ErrorBox onReset={() => props.reset()} />}>
-			<Suspense>
+			<Suspense fallback={<LoadingBox />}>
 				<SessionDetailInfoContainer sessionId={sessionId} />
 			</Suspense>
 		</ErrorBoundary>

--- a/apps/admin/app/(auth)/(split-session)/session/_components/SessionList.tsx
+++ b/apps/admin/app/(auth)/(split-session)/session/_components/SessionList.tsx
@@ -98,7 +98,13 @@ function SessionItem({ session }: { session: Session }) {
 export const SessionList = () => {
 	return (
 		<ErrorBoundary fallback={(props) => <ErrorBox onReset={() => props.reset()} />}>
-			<Suspense fallback={<LoadingBox />}>
+			<Suspense
+				fallback={
+					<div className="flex h-full flex-col">
+						<LoadingBox />
+					</div>
+				}
+			>
 				<SessionListContainer />
 			</Suspense>
 		</ErrorBoundary>

--- a/apps/admin/components/app-sidebar.tsx
+++ b/apps/admin/components/app-sidebar.tsx
@@ -78,7 +78,7 @@ export const AppSidebar = () => {
 		<Sidebar collapsible="icon" className="border-line-normal border-r">
 			<SidebarHeader className="p-4">
 				<Link href="/" className="flex items-center justify-center px-4.5 py-2.5">
-					<TextLogo className="hidden h-5 w-[144px] text-gray-400 lg:block" />
+					<TextLogo className="hidden h-5 w-36 text-gray-400 lg:block" />
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="block lg:hidden">
 						<title>Logo</title>
 						<path

--- a/apps/admin/components/loading-box.tsx
+++ b/apps/admin/components/loading-box.tsx
@@ -4,8 +4,8 @@ import { Loading } from './lotties/loading';
 
 const LoadingBox = () => {
 	return (
-		<div className="flex flex-1 flex-col items-center justify-center gap-y-3">
-			<div className="max-h-[800px] max-w-[800px]">
+		<div className="flex flex-1 flex-col items-center justify-center">
+			<div className="aspect-375/212 max-w-[375px]">
 				<Loading />
 			</div>
 		</div>

--- a/apps/client/app/(auth)/(attendance)/attendance/me/[sessionId]/page.tsx
+++ b/apps/client/app/(auth)/(attendance)/attendance/me/[sessionId]/page.tsx
@@ -1,4 +1,4 @@
-import { Fragment } from 'react';
+import { AppLayout } from '@dpm-core/shared';
 
 import { AppHeader } from '@/components/app-header';
 
@@ -12,9 +12,9 @@ export default async function page({ params }: AttendanceMeBySessionIdProps) {
 	const { sessionId } = await params;
 
 	return (
-		<Fragment>
+		<AppLayout className="bg-gray-0">
 			<AppHeader title="내 출석 상세" />
 			<AttendanceSessionDetail sessionId={Number(sessionId)} />
-		</Fragment>
+		</AppLayout>
 	);
 }

--- a/apps/client/components/loading-box.tsx
+++ b/apps/client/components/loading-box.tsx
@@ -4,8 +4,10 @@ import { Loading } from './lotties/loading';
 
 const LoadingBox = () => {
 	return (
-		<div className="flex flex-1 flex-col items-center justify-center gap-y-3">
-			<Loading />
+		<div className="flex flex-1 flex-col items-center justify-center">
+			<div className="aspect-375/212 max-w-[375px]">
+				<Loading />
+			</div>
 		</div>
 	);
 };

--- a/packages/shared/src/components/google-analytics/ga-initializer.tsx
+++ b/packages/shared/src/components/google-analytics/ga-initializer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect } from 'react';
+
 import { gaInit } from '../../utils/google-analytics';
 
 export const GAInitializer = () => {


### PR DESCRIPTION
## 📌 개요
로딩 로티 사이즈 가이드 적용

> 참고 링크
[DCQ-143 로딩 로티 사이즈](https://www.notion.so/depromeet/29f45b4338b380cfb692fbf14432a927?source=copy_link)
[피그마 링크](https://www.figma.com/design/ibSTW8dPTaOii5fo1KSZR4/%EB%94%94%ED%94%84%EB%A7%8C-%EC%BD%94%EC%96%B4%ED%8C%80?node-id=4463-37940&m=dev)
https://github.com/depromeet/dpm-core-client/pull/57#issue-3723184927

## 📋 변경사항
- 로딩 로티 사이즈 가이드

크게 적용되고 있던 로딩 로티 사이즈를 모바일, PC 뷰 모두 동일하게 가이드대로 적용하였습니다.
```css
width: 375px;
height: 212px;
```

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

### 스크린샷

| 작업 전 | 작업 후 |
| ------- | ------- |
| <img width="1507" height="857" alt="스크린샷 2025-12-12 오후 9 00 55" src="https://github.com/user-attachments/assets/e85bf03d-d96b-4ceb-941a-e34940f0d8b9" /> | <img width="1507" height="857" alt="스크린샷 2025-12-12 오후 8 58 20" src="https://github.com/user-attachments/assets/8db69227-5646-42c3-a1a4-56420d24c6b9" /> |

## 🙏 참고사항

> 리뷰어는 '참고사항'의 요소들을 고려해주세요.

### 리뷰 희망 기한



