### PR TITLE
feat: Super Admin 비공개 페이지 UI 퍼블리싱

### DIFF
--- a/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+import { useState } from 'react';
+import {
+	Button,
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+	toast,
+} from '@dpm-core/shared';
+
+interface CohortItem {
+	cohortId: number;
+	cohortNumber: string;
+}
+
+// TODO: API 연동 후 제거
+const MOCK_COHORTS: CohortItem[] = [
+	{ cohortId: 1, cohortNumber: '15기' },
+	{ cohortId: 2, cohortNumber: '16기' },
+	{ cohortId: 3, cohortNumber: '17기' },
+];
+
+export const CohortManagement = () => {
+	const [cohorts, setCohorts] = useState<CohortItem[]>(MOCK_COHORTS);
+	const [createDialogOpen, setCreateDialogOpen] = useState(false);
+	const [editDialogOpen, setEditDialogOpen] = useState(false);
+	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
+	const [inputValue, setInputValue] = useState('');
+	const [editTarget, setEditTarget] = useState<CohortItem | null>(null);
+	const [deleteTarget, setDeleteTarget] = useState<CohortItem | null>(null);
+
+	const handleCreate = () => {
+		if (!inputValue.trim()) return;
+		// TODO: API 연동
+		const newCohort: CohortItem = {
+			cohortId: Math.max(0, ...cohorts.map((c) => c.cohortId)) + 1,
+			cohortNumber: inputValue.trim(),
+		};
+		setCohorts((prev) => [...prev, newCohort]);
+		setCreateDialogOpen(false);
+		setInputValue('');
+		toast.success('기수가 생성되었습니다.');
+	};
+
+	const handleEdit = () => {
+		if (!editTarget || !inputValue.trim()) return;
+		// TODO: API 연동
+		setCohorts((prev) =>
+			prev.map((c) =>
+				c.cohortId === editTarget.cohortId ? { ...c, cohortNumber: inputValue.trim() } : c,
+			),
+		);
+		setEditDialogOpen(false);
+		setEditTarget(null);
+		setInputValue('');
+		toast.success('기수가 수정되었습니다.');
+	};
+
+	const handleDelete = () => {
+		if (!deleteTarget) return;
+		// TODO: API 연동
+		setCohorts((prev) => prev.filter((c) => c.cohortId !== deleteTarget.cohortId));
+		setDeleteDialogOpen(false);
+		setDeleteTarget(null);
+		toast.success('기수가 삭제되었습니다.');
+	};
+
+	const openEditDialog = (item: CohortItem) => {
+		setEditTarget(item);
+		setInputValue(item.cohortNumber);
+		setEditDialogOpen(true);
+	};
+
+	const openDeleteDialog = (item: CohortItem) => {
+		setDeleteTarget(item);
+		setDeleteDialogOpen(true);
+	};
+
+	return (
+		<div className="flex w-full flex-col gap-6">
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<div className="flex items-center gap-2">
+					<span className="font-bold text-label-normal text-title1">기수 목록</span>
+					<span className="font-medium text-body1 text-primary-normal">{cohorts.length}</span>
+				</div>
+				<Button
+					onClick={() => {
+						setInputValue('');
+						setCreateDialogOpen(true);
+					}}
+				>
+					기수 추가
+				</Button>
+			</div>
+
+			{/* Table */}
+			{cohorts.length === 0 ? (
+				<div className="flex min-h-[200px] w-full items-center justify-center py-12">
+					<p className="font-medium text-body1 text-label-assistive">등록된 기수가 없습니다</p>
+				</div>
+			) : (
+				<Table className="w-full">
+					<TableHeader>
+						<TableRow className="h-10 border-0 bg-background-strong hover:bg-background-strong">
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">
+								기수 ID
+							</TableHead>
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">
+								기수명
+							</TableHead>
+							<TableHead className="w-[200px] px-3 text-right font-medium text-body2 text-label-subtle">
+								관리
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{cohorts.map((c) => (
+							<TableRow key={c.cohortId} className="h-[56px] border-line-subtle">
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{c.cohortId}
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{c.cohortNumber}
+								</TableCell>
+								<TableCell className="flex items-center justify-end gap-2 px-3">
+									<button
+										type="button"
+										className="cursor-pointer rounded-md px-3 py-1.5 font-medium text-body2 text-label-normal hover:bg-background-strong"
+										onClick={() => openEditDialog(c)}
+									>
+										수정
+									</button>
+									<button
+										type="button"
+										className="cursor-pointer rounded-md px-3 py-1.5 font-medium text-body2 text-status-danger hover:bg-red-50"
+										onClick={() => openDeleteDialog(c)}
+									>
+										삭제
+									</button>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
+
+			{/* Create Dialog */}
+			<Dialog open={createDialogOpen} onOpenChange={setCreateDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>기수 추가</DialogTitle>
+						<DialogDescription>새로운 기수를 생성합니다. 최신 기수 역할이 자동 생성됩니다.</DialogDescription>
+					</DialogHeader>
+					<input
+						type="text"
+						placeholder="기수명 (예: 17기)"
+						value={inputValue}
+						onChange={(e) => setInputValue(e.target.value)}
+						className="w-full rounded-lg border border-line-normal bg-background-normal px-4 py-3 font-medium text-body1 text-label-normal outline-none focus:border-primary-normal"
+					/>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="assistive">취소</Button>
+						</DialogClose>
+						<Button onClick={handleCreate} disabled={!inputValue.trim()}>
+							생성
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Edit Dialog */}
+			<Dialog open={editDialogOpen} onOpenChange={setEditDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>기수 수정</DialogTitle>
+						<DialogDescription>
+							{editTarget?.cohortNumber} 기수의 값을 수정합니다.
+						</DialogDescription>
+					</DialogHeader>
+					<input
+						type="text"
+						placeholder="기수명"
+						value={inputValue}
+						onChange={(e) => setInputValue(e.target.value)}
+						className="w-full rounded-lg border border-line-normal bg-background-normal px-4 py-3 font-medium text-body1 text-label-normal outline-none focus:border-primary-normal"
+					/>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="assistive">취소</Button>
+						</DialogClose>
+						<Button onClick={handleEdit} disabled={!inputValue.trim()}>
+							수정
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+
+			{/* Delete Dialog */}
+			<Dialog open={deleteDialogOpen} onOpenChange={setDeleteDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>기수 삭제</DialogTitle>
+						<DialogDescription>
+							{deleteTarget?.cohortNumber} 기수를 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="assistive">취소</Button>
+						</DialogClose>
+						<Button variant="secondary" onClick={handleDelete}>
+							삭제
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+};

--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+export const PermissionManagement = () => {
+	return (
+		<div className="flex w-full flex-col gap-6">
+			<div className="flex items-center justify-between">
+				<span className="font-bold text-label-normal text-title1">권한 관리</span>
+			</div>
+			<div className="flex min-h-[300px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
+				<p className="font-medium text-body1 text-label-assistive">
+					권한 관리 API 연동 후 구현 예정
+				</p>
+			</div>
+		</div>
+	);
+};

--- a/apps/admin/app/(auth)/super-admin/_components/SuperAdminTabs.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/SuperAdminTabs.tsx
@@ -1,0 +1,48 @@
+'use client';
+
+import { useState } from 'react';
+import { cn } from '@dpm-core/shared';
+
+import { CohortManagement } from './CohortManagement';
+import { PermissionManagement } from './PermissionManagement';
+import { UserHardDelete } from './UserHardDelete';
+
+const TABS = [
+	{ key: 'cohort', label: '기수 관리' },
+	{ key: 'permission', label: '권한 관리' },
+	{ key: 'user-delete', label: '유저 삭제' },
+] as const;
+
+type TabKey = (typeof TABS)[number]['key'];
+
+export const SuperAdminTabs = () => {
+	const [activeTab, setActiveTab] = useState<TabKey>('cohort');
+
+	return (
+		<div className="mx-auto flex w-full max-w-[1200px] flex-col items-start gap-6 px-4 pt-8 md:px-10">
+			{/* Tab Headers */}
+			<div className="flex w-full border-line-normal border-b">
+				{TABS.map((tab) => (
+					<button
+						key={tab.key}
+						type="button"
+						className={cn(
+							'cursor-pointer px-4 py-3 font-semibold text-body1 transition-colors',
+							activeTab === tab.key
+								? 'border-label-normal border-b-2 text-label-normal'
+								: 'text-label-assistive hover:text-label-subtle',
+						)}
+						onClick={() => setActiveTab(tab.key)}
+					>
+						{tab.label}
+					</button>
+				))}
+			</div>
+
+			{/* Tab Content */}
+			{activeTab === 'cohort' && <CohortManagement />}
+			{activeTab === 'permission' && <PermissionManagement />}
+			{activeTab === 'user-delete' && <UserHardDelete />}
+		</div>
+	);
+};

--- a/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { useState } from 'react';
+import {
+	Button,
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
+	SearchInputOutlined,
+	toast,
+} from '@dpm-core/shared';
+
+export const UserHardDelete = () => {
+	const [searchQuery, setSearchQuery] = useState('');
+	const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
+	const [targetUser, setTargetUser] = useState<string | null>(null);
+
+	const handleSearch = () => {
+		// TODO: 유저 검색 API 연동
+		toast.info('유저 검색 API 연동 후 구현 예정');
+	};
+
+	const handleConfirmDelete = () => {
+		// TODO: member_oauth 값과 이메일 변경하여 하드 딜리트 처리
+		toast.info('유저 삭제 API 연동 후 구현 예정');
+		setConfirmDialogOpen(false);
+		setTargetUser(null);
+	};
+
+	return (
+		<div className="flex w-full flex-col gap-6">
+			<div className="flex flex-col gap-2">
+				<span className="font-bold text-label-normal text-title1">유저 하드 딜리트</span>
+				<p className="text-body2 text-label-subtle">
+					기존 계정 정보에서 member_oauth 값과 이메일만 변경하여 하드 딜리트된 것처럼 처리합니다.
+				</p>
+			</div>
+
+			{/* Search */}
+			<div className="flex items-center gap-3">
+				<div className="w-[400px]">
+					<SearchInputOutlined
+						placeholder="유저 이름 또는 이메일 검색"
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						className="h-10 w-full"
+					/>
+				</div>
+				<Button onClick={handleSearch}>검색</Button>
+			</div>
+
+			{/* Placeholder */}
+			<div className="flex min-h-[200px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
+				<p className="font-medium text-body1 text-label-assistive">
+					유저를 검색하여 삭제 대상을 선택하세요
+				</p>
+			</div>
+
+			{/* Confirm Dialog */}
+			<Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>유저 삭제 확인</DialogTitle>
+						<DialogDescription>
+							{targetUser} 유저를 하드 딜리트 처리하시겠습니까?
+							<br />
+							member_oauth 값과 이메일이 변경되며, 이 작업은 되돌릴 수 없습니다.
+						</DialogDescription>
+					</DialogHeader>
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="assistive">취소</Button>
+						</DialogClose>
+						<Button variant="secondary" onClick={handleConfirmDelete}>
+							삭제
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
+		</div>
+	);
+};

--- a/apps/admin/app/(auth)/super-admin/page.tsx
+++ b/apps/admin/app/(auth)/super-admin/page.tsx
@@ -1,0 +1,14 @@
+import { AppLayout } from '@dpm-core/shared';
+
+import { AppHeader } from '@/components/app-header';
+
+import { SuperAdminTabs } from './_components/SuperAdminTabs';
+
+export default function SuperAdminPage() {
+	return (
+		<AppLayout className="flex flex-col bg-background-normal">
+			<AppHeader title="Super Admin" />
+			<SuperAdminTabs />
+		</AppLayout>
+	);
+}

--- a/apps/admin/components/app-sidebar.tsx
+++ b/apps/admin/components/app-sidebar.tsx
@@ -228,7 +228,14 @@ export const AppSidebar = () => {
 	return (
 		<Sidebar collapsible="icon" className="border-line-normal border-r">
 			<SidebarHeader className="p-4">
-				<Link href="/" className="flex items-center justify-center px-4.5 py-2.5">
+				<Link
+					href="/"
+					className="flex items-center justify-center px-4.5 py-2.5"
+					onDoubleClick={(e: React.MouseEvent) => {
+						e.preventDefault();
+						window.location.href = '/super-admin';
+					}}
+				>
 					<TextLogo className="hidden h-5 w-36 text-gray-400 lg:block" />
 					<svg width="24" height="24" viewBox="0 0 24 24" fill="none" className="block lg:hidden">
 						<title>Logo</title>


### PR DESCRIPTION
## Summary
- `/super-admin` 비공개 페이지 UI 퍼블리싱 (사이드바 로고 더블클릭으로 진입)
- 기수 관리 탭: 테이블 목록 + 추가/수정/삭제 다이얼로그 (mock 데이터)
- 권한 관리 탭: placeholder (API 연동 예정)
- 유저 하드 딜리트 탭: 검색 UI + 삭제 확인 다이얼로그 (API 연동 예정)

## Test plan
- [ ] `/super-admin` 접속 확인
- [ ] 사이드바 로고 더블클릭으로 진입 확인
- [ ] 기수 관리 탭: 추가/수정/삭제 다이얼로그 동작 확인
- [ ] 각 탭 전환 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)