### PR TITLE
feat: 푸시 토큰 등록 api 연동

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -8,10 +8,10 @@ project_name: "dpm-core-client"
 #   fortran             fsharp              go                  groovy              haskell
 #   java                julia               kotlin              lua                 markdown
 #   matlab              nix                 pascal              perl                php
-#   powershell          python              python_jedi         r                   rego
-#   ruby                ruby_solargraph     rust                scala               swift
-#   terraform           toml                typescript          typescript_vts      vue
-#   yaml                zig
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
 #   (This list may be outdated. For the current list, see values of Language enum here:
 #   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
 #   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
@@ -35,8 +35,9 @@ encoding: "utf-8"
 # whether to use project's .gitignore files to ignore files
 ignore_all_files_in_gitignore: true
 
-# list of additional paths to ignore in all projects
-# same syntax as gitignore, so you can use * and **
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
 ignored_paths: []
 
 # whether the project is in read-only mode
@@ -44,7 +45,9 @@ ignored_paths: []
 # Added on 2025-04-18
 read_only: false
 
-# list of tool names to exclude. We recommend not excluding any tools, see the readme for more details.
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
 # Below is the complete list of tools for convenience.
 # To make sure you have the latest list of tools, and to view their descriptions, 
 # execute `uv run scripts/print_tool_overview.py`.
@@ -85,7 +88,8 @@ read_only: false
 #  * `write_memory`: Writes a named memory (for future reference) to Serena's project-specific memory store.
 excluded_tools: []
 
-# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default)
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
 included_optional_tools: []
 
 # fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
@@ -132,3 +136,17 @@ line_ending:
 # list of regex patterns which, when matched, mark a memory entry as read‑only.
 # Extends the list from the global configuration, merging the two lists.
 read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}

--- a/apps/client/hooks/use-push-notification.ts
+++ b/apps/client/hooks/use-push-notification.ts
@@ -1,0 +1,29 @@
+'use client';
+
+import { useMutation } from '@tanstack/react-query';
+
+import { useAppConfig } from '@/providers/app-config-provider';
+import { useBridgeStatus, useBridgeStore } from '@/providers/bridge-provider';
+import { registerPushTokenMutationOptions } from '@/remotes/mutations/notification';
+
+export function usePushNotification() {
+	const { isApp } = useAppConfig();
+	const { isWebViewBridgeAvailable, isNativeMethodAvailable } = useBridgeStatus();
+	const requestPushPermission = useBridgeStore(
+		({ requestPushPermission }) => requestPushPermission,
+	);
+	const { mutate: registerToken } = useMutation(registerPushTokenMutationOptions());
+
+	const requestAndRegister = async () => {
+		if (!isApp || !isWebViewBridgeAvailable || !isNativeMethodAvailable('requestPushPermission'))
+			return;
+
+		const result = await requestPushPermission();
+
+		if (result.success) {
+			registerToken(result.token);
+		}
+	};
+
+	return { requestAndRegister };
+}

--- a/apps/client/hooks/use-push-notification.ts
+++ b/apps/client/hooks/use-push-notification.ts
@@ -12,16 +12,20 @@ export function usePushNotification() {
 	const requestPushPermission = useBridgeStore(
 		({ requestPushPermission }) => requestPushPermission,
 	);
-	const { mutate: registerToken } = useMutation(registerPushTokenMutationOptions());
+	const { mutateAsync: registerToken } = useMutation(registerPushTokenMutationOptions());
 
-	const requestAndRegister = async () => {
+	const requestAndRegister = async (): Promise<boolean> => {
 		if (!isApp || !isWebViewBridgeAvailable || !isNativeMethodAvailable('requestPushPermission'))
-			return;
+			return false;
 
-		const result = await requestPushPermission();
+		try {
+			const result = await requestPushPermission();
+			if (!result.success) return false;
 
-		if (result.success) {
-			registerToken(result.token);
+			await registerToken(result.token);
+			return true;
+		} catch {
+			return false;
 		}
 	};
 

--- a/apps/client/providers/auth-provider.tsx
+++ b/apps/client/providers/auth-provider.tsx
@@ -57,7 +57,9 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
 
 			if (!pushRegistered.current) {
 				pushRegistered.current = true;
-				requestAndRegister();
+				void requestAndRegister().then((success) => {
+					if (!success) pushRegistered.current = false;
+				});
 			}
 		}
 	}, [memberInfo, requestAndRegister]);

--- a/apps/client/providers/auth-provider.tsx
+++ b/apps/client/providers/auth-provider.tsx
@@ -1,12 +1,13 @@
 'use client';
 
 import { redirect, usePathname } from 'next/navigation';
-import { type PropsWithChildren, useEffect, useState } from 'react';
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { auth, type Member } from '@dpm-core/api';
 import { createContext, toast } from '@dpm-core/shared';
 
 import { UnauthenticatedLayout } from '@/components/unauthenticated-layout';
+import { usePushNotification } from '@/hooks/use-push-notification';
 import { getMyMemberInfoQuery } from '@/remotes/queries/member';
 
 interface AuthContextType {
@@ -27,8 +28,11 @@ const [AuthProviderContext, useAuth] = createContext<AuthContextType>('Auth', {
 const AuthProvider = ({ children }: PropsWithChildren) => {
 	const [isAuthenticated, setIsAuthenticated] = useState(false);
 	const [user, setUser] = useState<Member | null>(null);
-	const pathname = usePathname();
 
+	const pushRegistered = useRef(false);
+
+	const pathname = usePathname();
+	const { requestAndRegister } = usePushNotification();
 	const queryClient = useQueryClient();
 
 	const {
@@ -50,8 +54,13 @@ const AuthProvider = ({ children }: PropsWithChildren) => {
 		if (memberInfo) {
 			setIsAuthenticated(true);
 			setUser(memberInfo);
+
+			if (!pushRegistered.current) {
+				pushRegistered.current = true;
+				requestAndRegister();
+			}
 		}
-	}, [memberInfo]);
+	}, [memberInfo, requestAndRegister]);
 
 	// 미로그인 인 경우, 접속 하자마자 홈으로 진입으로 변경, 로그인 페이지로 바로 진입아님
 	if (error && pathname !== '/login') {

--- a/apps/client/remotes/mutations/notification.ts
+++ b/apps/client/remotes/mutations/notification.ts
@@ -1,0 +1,8 @@
+import { mutationOptions } from '@tanstack/react-query';
+import { notification } from '@dpm-core/api';
+
+export const registerPushTokenMutationOptions = () =>
+	mutationOptions({
+		mutationKey: ['push-token', 'register'],
+		mutationFn: (token: string) => notification.registerPushToken({ token }),
+	});

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -1,4 +1,15 @@
+import * as Notifications from 'expo-notifications';
 import { SplashScreen, Stack } from 'expo-router';
+
+// 앱이 포그라운드일 때 수신된 알림 표시 방식 설정
+Notifications.setNotificationHandler({
+	handleNotification: async () => ({
+		shouldPlaySound: true,
+		shouldSetBadge: true,
+		shouldShowBanner: true,
+		shouldShowList: true,
+	}),
+});
 
 SplashScreen.preventAutoHideAsync();
 

--- a/apps/native/bridge/app-bridge.ts
+++ b/apps/native/bridge/app-bridge.ts
@@ -1,12 +1,23 @@
 import { bridge } from '@webview-bridge/react-native';
 import * as WebBrowser from 'expo-web-browser';
 
+import { requestPushNotificationPermission } from '@/lib/push-notification-permission';
+
 export const appBridge = bridge({
 	async getTriggerWeb() {
 		return '웹에서 네이티브로 접근!';
 	},
 	async openInAppBrowser(url: string) {
 		return await WebBrowser.openBrowserAsync(url);
+	},
+	async requestPushPermission() {
+		try {
+			const token = await requestPushNotificationPermission();
+			return { success: true as const, token };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
+			return { success: false as const, error: message };
+		}
 	},
 });
 

--- a/apps/native/lib/push-notification-permission.ts
+++ b/apps/native/lib/push-notification-permission.ts
@@ -29,7 +29,8 @@ export async function requestPushNotificationPermission(): Promise<string> {
 		throw new Error('푸시 알람 권한이 없습니다.');
 	}
 
-	const projectId = Constants?.expoConfig?.extra?.eas?.projectId;
+	const projectId =
+		Constants?.expoConfig?.extra?.eas?.projectId ?? Constants?.easConfig?.projectId;
 	if (!projectId) {
 		throw new Error('EAS Project ID가 설정되지 않았습니다.');
 	}

--- a/apps/native/lib/push-notification-permission.ts
+++ b/apps/native/lib/push-notification-permission.ts
@@ -1,8 +1,9 @@
+import Constants from 'expo-constants';
 import * as Device from 'expo-device';
 import * as Notifications from 'expo-notifications';
 import { Platform } from 'react-native';
 
-export async function requestPushNotificationPermission() {
+export async function requestPushNotificationPermission(): Promise<string> {
 	if (Platform.OS === 'android') {
 		await Notifications.setNotificationChannelAsync('default', {
 			name: 'default',
@@ -26,7 +27,13 @@ export async function requestPushNotificationPermission() {
 
 	if (finalStatus !== 'granted') {
 		throw new Error('푸시 알람 권한이 없습니다.');
-	} else {
-		// 알람 권한이 있는 경우 서버로 토큰 전송
 	}
+
+	const projectId = Constants?.expoConfig?.extra?.eas?.projectId;
+	if (!projectId) {
+		throw new Error('EAS Project ID가 설정되지 않았습니다.');
+	}
+
+	const { data: token } = await Notifications.getExpoPushTokenAsync({ projectId });
+	return token;
 }

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -24,6 +24,7 @@
 		"expo": "~54.0.30",
 		"expo-build-properties": "~1.0.10",
 		"expo-constants": "~18.0.12",
+		"expo-dev-client": "~6.0.20",
 		"expo-device": "~8.0.10",
 		"expo-font": "~14.0.10",
 		"expo-haptics": "~15.0.8",

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -8,5 +8,6 @@ export * from './constants';
 export * from './env';
 export * from './http';
 export * from './member';
+export * from './notification';
 export * from './session';
 export type * from './type';

--- a/packages/api/src/notification/index.ts
+++ b/packages/api/src/notification/index.ts
@@ -1,0 +1,2 @@
+export * from './remote';
+export type * from './types';

--- a/packages/api/src/notification/remote.ts
+++ b/packages/api/src/notification/remote.ts
@@ -1,9 +1,8 @@
 import { http } from '../http';
-import type { RegisterPushTokenRequest } from './types';
+import type { RegisterPushTokenRequest, RegisterPushTokenResponse } from './types';
 
 export const notification = {
-	// TODO: 백엔드 API 엔드포인트 확정 후 수정 필요 (서버 명세 문서 참고)
 	registerPushToken: async (params: RegisterPushTokenRequest) => {
-		await http.post('v1/notifications/token', { json: params });
+		return http.post<RegisterPushTokenResponse>('v1/notifications/tokens', { json: params });
 	},
 };

--- a/packages/api/src/notification/remote.ts
+++ b/packages/api/src/notification/remote.ts
@@ -1,0 +1,9 @@
+import { http } from '../http';
+import type { RegisterPushTokenRequest } from './types';
+
+export const notification = {
+	// TODO: 백엔드 API 엔드포인트 확정 후 수정 필요 (서버 명세 문서 참고)
+	registerPushToken: async (params: RegisterPushTokenRequest) => {
+		await http.post('v1/notifications/token', { json: params });
+	},
+};

--- a/packages/api/src/notification/types.ts
+++ b/packages/api/src/notification/types.ts
@@ -1,0 +1,3 @@
+export interface RegisterPushTokenRequest {
+	token: string;
+}

--- a/packages/api/src/notification/types.ts
+++ b/packages/api/src/notification/types.ts
@@ -1,3 +1,11 @@
 export interface RegisterPushTokenRequest {
 	token: string;
 }
+
+export interface RegisterPushTokenResponse {
+	id: number;
+	memberId: number;
+	token: string;
+	createdAt: string;
+	updatedAt: string;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -281,6 +281,9 @@ importers:
       expo-constants:
         specifier: ~18.0.12
         version: 18.0.13(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))
+      expo-dev-client:
+        specifier: ~6.0.20
+        version: 6.0.20(expo@54.0.33)
       expo-device:
         specifier: ~8.0.10
         version: 8.0.10(expo@54.0.33)
@@ -2941,6 +2944,7 @@ packages:
   '@xmldom/xmldom@0.8.11':
     resolution: {integrity: sha512-cQzWCtO6C8TQiYl1ruKNn2U6Ao4o4WBBcbL61yJl84x+j5sOWWFU9X7DpND8XZG3daDppSsigMdfAIl2upQBRw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   abort-controller@3.0.0:
     resolution: {integrity: sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==}
@@ -3735,6 +3739,26 @@ packages:
       expo: '*'
       react-native: '*'
 
+  expo-dev-client@6.0.20:
+    resolution: {integrity: sha512-5XjoVlj1OxakNxy55j/AUaGPrDOlQlB6XdHLLWAw61w5ffSpUDHDnuZzKzs9xY1eIaogOqTOQaAzZ2ddBkdXLA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-launcher@6.0.20:
+    resolution: {integrity: sha512-a04zHEeT9sB0L5EB38fz7sNnUKJ2Ar1pXpcyl60Ki8bXPNCs9rjY7NuYrDkP/irM8+1DklMBqHpyHiLyJ/R+EA==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu-interface@2.0.0:
+    resolution: {integrity: sha512-BvAMPt6x+vyXpThsyjjOYyjwfjREV4OOpQkZ0tNl+nGpsPfcY9mc6DRACoWnH9KpLzyIt3BOgh3cuy/h/OxQjw==}
+    peerDependencies:
+      expo: '*'
+
+  expo-dev-menu@7.0.18:
+    resolution: {integrity: sha512-4kTdlHrnZCAWCT6tZRQHSSjZ7vECFisL4T+nsG/GJDo/jcHNaOVGV5qPV9wzlTxyMk3YOPggRw4+g7Ownrg5eA==}
+    peerDependencies:
+      expo: '*'
+
   expo-device@8.0.10:
     resolution: {integrity: sha512-jd5BxjaF7382JkDMaC+P04aXXknB2UhWaVx5WiQKA05ugm/8GH5uaz9P9ckWdMKZGQVVEOC8MHaUADoT26KmFA==}
     peerDependencies:
@@ -3769,6 +3793,9 @@ packages:
       react-native-web:
         optional: true
 
+  expo-json-utils@0.15.0:
+    resolution: {integrity: sha512-duRT6oGl80IDzH2LD2yEFWNwGIC2WkozsB6HF3cDYNoNNdUvFk6uN3YiwsTsqVM/D0z6LEAQ01/SlYvN+Fw0JQ==}
+
   expo-keep-awake@15.0.8:
     resolution: {integrity: sha512-YK9M1VrnoH1vLJiQzChZgzDvVimVoriibiDIFLbQMpjYBnvyfUeHJcin/Gx1a+XgupNXy92EQJLgI/9ZuXajYQ==}
     peerDependencies:
@@ -3780,6 +3807,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-manifests@1.0.10:
+    resolution: {integrity: sha512-oxDUnURPcL4ZsOBY6X1DGWGuoZgVAFzp6PISWV7lPP2J0r8u1/ucuChBgpK7u1eLGFp6sDIPwXyEUCkI386XSQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-modules-autolinking@3.0.24:
     resolution: {integrity: sha512-TP+6HTwhL7orDvsz2VzauyQlXJcAWyU3ANsZ7JGL4DQu8XaZv/A41ZchbtAYLfozNA2Ya1Hzmhx65hXryBMjaQ==}
@@ -3862,6 +3894,11 @@ packages:
     peerDependenciesMeta:
       react-native-web:
         optional: true
+
+  expo-updates-interface@2.0.0:
+    resolution: {integrity: sha512-pTzAIufEZdVPKql6iMi5ylVSPqV1qbEopz9G6TSECQmnNde2nwq42PxdFBaUEd8IZJ/fdJLQnOT3m6+XJ5s7jg==}
+    peerDependencies:
+      expo: '*'
 
   expo-web-browser@15.0.10:
     resolution: {integrity: sha512-fvDhW4bhmXAeWFNFiInmsGCK83PAqAcQaFyp/3pE/jbdKmFKoRCWr46uZGIfN4msLK/OODhaQ/+US7GSJNDHJg==}
@@ -10063,6 +10100,35 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  expo-dev-client@6.0.20(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-dev-launcher: 6.0.20(expo@54.0.33)
+      expo-dev-menu: 7.0.18(expo@54.0.33)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.33)
+      expo-manifests: 1.0.10(expo@54.0.33)
+      expo-updates-interface: 2.0.0(expo@54.0.33)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-dev-launcher@6.0.20(expo@54.0.33):
+    dependencies:
+      ajv: 8.18.0
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-dev-menu: 7.0.18(expo@54.0.33)
+      expo-manifests: 1.0.10(expo@54.0.33)
+    transitivePeerDependencies:
+      - supports-color
+
+  expo-dev-menu-interface@2.0.0(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  expo-dev-menu@7.0.18(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-dev-menu-interface: 2.0.0(expo@54.0.33)
+
   expo-device@8.0.10(expo@54.0.33):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -10092,6 +10158,8 @@ snapshots:
     optionalDependencies:
       react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
 
+  expo-json-utils@0.15.0: {}
+
   expo-keep-awake@15.0.8(expo@54.0.33)(react@19.1.0):
     dependencies:
       expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -10105,6 +10173,14 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - expo
+      - supports-color
+
+  expo-manifests@1.0.10(expo@54.0.33):
+    dependencies:
+      '@expo/config': 12.0.13
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-json-utils: 0.15.0
+    transitivePeerDependencies:
       - supports-color
 
   expo-modules-autolinking@3.0.24:
@@ -10210,6 +10286,10 @@ snapshots:
       react-native-web: 0.21.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-updates-interface@2.0.0(expo@54.0.33):
+    dependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
 
   expo-web-browser@15.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:


### PR DESCRIPTION
## 📌 개요

> 참고 링크

## 📋 변경사항

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

1. fcm 푸시 알림 기능 관련 세팅
[ Native ]
- Expo Push Token 획득 후 반환하도록 설정
- requestPushPermission() 브릿지 메서드 추가
- 포그라운드 알림 표시 핸들러 추가

[ Web Client ]
- 브릿지 호출 + 토큰 서버 등록 훅 신규 생성

2. 푸시 토큰 등록 api 연동

### 스크린샷

| 작업 전 | 작업 후 |
| ------- | ------- |

## 🙏 참고사항

> 리뷰어는 '참고사항'의 요소들을 고려해주세요.

### 리뷰 희망 기한



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 푸시 알림 권한 요청과 Expo 토큰 획득 및 서버 등록 흐름 추가
  * 네이티브 앱에서 포그라운드 알림 표시(사운드/배지/배너/리스트) 활성화

* **설정 업데이트**
  * 프로젝트 설정에 메모리 필터링용 패턴(ignored_memory_patterns) 추가
  * 언어별 언어서버 전용 옵션(ls_specific_settings) 설정 가능성 추가
<!-- end of auto-generated comment: release notes by coderabbit.ai -->