### PR TITLE
feat: 권한관리 탭 검색/정렬 기능 추가

### DIFF
--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -1,16 +1,187 @@
 'use client';
 
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ArrowDownAZ, ArrowUpAZ } from 'lucide-react';
+import {
+	SearchInputOutlined,
+	StatusBadge,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
+} from '@dpm-core/shared';
+
+import { getCohortListQuery } from '@/remotes/queries/cohort';
+import { getMembersOverviewQuery } from '@/remotes/queries/member';
+
+type SortKey = 'memberId' | 'name' | 'cohortId' | 'part' | 'status';
+type SortOrder = 'asc' | 'desc';
+
+const SORT_COLUMNS = [
+	{ key: 'memberId', label: 'ID' },
+	{ key: 'name', label: '이름' },
+	{ key: 'cohortId', label: '기수' },
+	{ key: 'part', label: '파트' },
+	{ key: 'status', label: '상태' },
+] as const;
+
+const statusBadgeStatus = (status: string) => {
+	switch (status) {
+		case 'ACTIVE':
+			return 'success';
+		case 'PENDING':
+			return 'pending';
+		case 'INACTIVE':
+			return 'warning';
+		case 'WITHDRAWN':
+			return 'error';
+		default:
+			return 'default';
+	}
+};
+
 export const PermissionManagement = () => {
+	const { data: membersData, isLoading: membersLoading } = useQuery(getMembersOverviewQuery());
+	const { data: cohortsData } = useQuery(getCohortListQuery);
+
+	const members = membersData?.data.members ?? [];
+	const cohorts = cohortsData?.data.cohorts ?? [];
+	const cohortMap = new Map(cohorts.map((c) => [c.cohortId, c.cohortNumber]));
+
+	const [searchQuery, setSearchQuery] = useState('');
+	const [sortKey, setSortKey] = useState<SortKey>('memberId');
+	const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+
+	const handleSort = (key: SortKey) => {
+		if (sortKey === key) {
+			setSortOrder((prev) => (prev === 'asc' ? 'desc' : 'asc'));
+		} else {
+			setSortKey(key);
+			setSortOrder('asc');
+		}
+	};
+
+	const filteredAndSortedMembers = useMemo(() => {
+		const query = searchQuery.trim().toLowerCase();
+
+		const filtered = query
+			? members.filter((m) => {
+					const cohortNumber = cohortMap.get(m.cohortId) ?? String(m.cohortId);
+					return (
+						String(m.memberId).includes(query) ||
+						m.name.toLowerCase().includes(query) ||
+						m.part.toLowerCase().includes(query) ||
+						m.status.toLowerCase().includes(query) ||
+						cohortNumber.toLowerCase().includes(query)
+					);
+				})
+			: members;
+
+		return [...filtered].sort((a, b) => {
+			const dir = sortOrder === 'asc' ? 1 : -1;
+			switch (sortKey) {
+				case 'memberId':
+					return (a.memberId - b.memberId) * dir;
+				case 'name':
+					return a.name.localeCompare(b.name) * dir;
+				case 'cohortId':
+					return (a.cohortId - b.cohortId) * dir;
+				case 'part':
+					return a.part.localeCompare(b.part) * dir;
+				case 'status':
+					return a.status.localeCompare(b.status) * dir;
+				default:
+					return 0;
+			}
+		});
+	}, [members, searchQuery, sortKey, sortOrder, cohortMap]);
+
 	return (
 		<div className="flex w-full flex-col gap-6">
+			{/* Header */}
 			<div className="flex items-center justify-between">
-				<span className="font-bold text-label-normal text-title1">권한 관리</span>
+				<div className="flex items-center gap-2">
+					<span className="font-bold text-label-normal text-title1">권한 관리</span>
+					<span className="font-medium text-body1 text-primary-normal">
+						{filteredAndSortedMembers.length}
+					</span>
+				</div>
+				<div className="w-[320px]">
+					<SearchInputOutlined
+						placeholder="ID, 이름, 파트, 상태 검색"
+						value={searchQuery}
+						onChange={(e) => setSearchQuery(e.target.value)}
+						className="h-10 w-full"
+					/>
+				</div>
 			</div>
-			<div className="flex min-h-[300px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
-				<p className="font-medium text-body1 text-label-assistive">
-					권한 관리 API 연동 후 구현 예정
-				</p>
-			</div>
+
+			{/* Table */}
+			{membersLoading ? (
+				<div className="flex min-h-[300px] w-full items-center justify-center py-12">
+					<p className="font-medium text-body1 text-label-assistive">멤버 목록을 불러오는 중...</p>
+				</div>
+			) : filteredAndSortedMembers.length === 0 ? (
+				<div className="flex min-h-[300px] w-full items-center justify-center py-12">
+					<p className="font-medium text-body1 text-label-assistive">
+						{searchQuery ? '검색 결과가 없습니다' : '등록된 멤버가 없습니다'}
+					</p>
+				</div>
+			) : (
+				<Table className="w-full">
+					<TableHeader>
+						<TableRow className="h-10 border-0 bg-background-strong hover:bg-background-strong">
+							{SORT_COLUMNS.map((col) => (
+								<TableHead key={col.key} className="px-3 font-medium text-body2 text-label-subtle">
+									<button
+										type="button"
+										className="inline-flex cursor-pointer items-center gap-1"
+										onClick={() => handleSort(col.key)}
+									>
+										{col.label}
+										{sortKey === col.key &&
+											(sortOrder === 'asc' ? (
+												<ArrowUpAZ className="size-3.5" />
+											) : (
+												<ArrowDownAZ className="size-3.5" />
+											))}
+									</button>
+								</TableHead>
+							))}
+							<TableHead className="w-[200px] px-3 text-right font-medium text-body2 text-label-subtle">
+								관리
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{filteredAndSortedMembers.map((m) => (
+							<TableRow key={m.memberId} className="h-[56px] border-line-subtle">
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.memberId}
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.name}
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{cohortMap.get(m.cohortId) ?? m.cohortId}기
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.part}
+								</TableCell>
+								<TableCell className="px-3">
+									<StatusBadge status={statusBadgeStatus(m.status)}>{m.status}</StatusBadge>
+								</TableCell>
+								<TableCell className="px-3 text-right font-medium text-body2 text-label-assistive">
+									API 연동 후 추가 예정
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
 		</div>
 	);
 };

--- a/apps/admin/remotes/mutations/cohort.ts
+++ b/apps/admin/remotes/mutations/cohort.ts
@@ -1,0 +1,39 @@
+import { type MutationOptions, mutationOptions } from '@tanstack/react-query';
+import { cohort } from '@dpm-core/api';
+import type { CreateCohortRequest, UpdateCohortRequest } from '@dpm-core/api';
+
+export const createCohortMutationOptions = (
+	options?: MutationOptions<
+		Awaited<ReturnType<typeof cohort.create>>,
+		Error,
+		CreateCohortRequest
+	>,
+) =>
+	mutationOptions({
+		mutationKey: ['cohort', 'create'],
+		mutationFn: (params: CreateCohortRequest) => cohort.create(params),
+		...options,
+	});
+
+export const updateCohortMutationOptions = (
+	options?: MutationOptions<
+		Awaited<ReturnType<typeof cohort.update>>,
+		Error,
+		{ cohortId: number; params: UpdateCohortRequest }
+	>,
+) =>
+	mutationOptions({
+		mutationKey: ['cohort', 'update'],
+		mutationFn: ({ cohortId, params }: { cohortId: number; params: UpdateCohortRequest }) =>
+			cohort.update(cohortId, params),
+		...options,
+	});
+
+export const deleteCohortMutationOptions = (
+	options?: MutationOptions<Awaited<ReturnType<typeof cohort.delete>>, Error, number>,
+) =>
+	mutationOptions({
+		mutationKey: ['cohort', 'delete'],
+		mutationFn: (cohortId: number) => cohort.delete(cohortId),
+		...options,
+	});

--- a/apps/admin/remotes/queries/cohort.ts
+++ b/apps/admin/remotes/queries/cohort.ts
@@ -1,0 +1,14 @@
+import { queryOptions } from '@tanstack/react-query';
+import { cohort } from '@dpm-core/api';
+
+export const COHORT_LIST_QUERY_KEY = ['cohort-list'] as const;
+
+export const getCohortListQuery = queryOptions({
+	queryKey: COHORT_LIST_QUERY_KEY,
+	queryFn: () => cohort.getList(),
+});
+
+export const getCohortLatestQuery = queryOptions({
+	queryKey: ['cohort-latest'],
+	queryFn: () => cohort.getLatest(),
+});

--- a/packages/api/src/cohort/remote.ts
+++ b/packages/api/src/cohort/remote.ts
@@ -1,9 +1,44 @@
 import { http } from '../http';
-import type { Cohort } from './types';
+import type {
+	CohortItem,
+	CohortListResponse,
+	CreateCohortRequest,
+	UpdateCohortRequest,
+} from './types';
 
 export const cohort = {
 	getCurrentCohort: async () => {
-		const res = await http.get<{ cohortNumber: Cohort }>('v1/cohort');
+		const res = await http.get<{ cohortNumber: string }>('v1/cohort');
+		return res;
+	},
+
+	/** GET /v1/cohorts - 전체 기수 목록 조회 */
+	getList: async () => {
+		const res = await http.get<CohortListResponse>('v1/cohorts');
+		return res;
+	},
+
+	/** GET /v1/cohorts/latest - 최신 기수 조회 */
+	getLatest: async () => {
+		const res = await http.get<CohortItem>('v1/cohorts/latest');
+		return res;
+	},
+
+	/** POST /v1/cohorts - 기수 생성 */
+	create: async (params: CreateCohortRequest) => {
+		const res = await http.post<CohortItem>('v1/cohorts', { json: params });
+		return res;
+	},
+
+	/** PUT /v1/cohorts/{cohortId} - 기수 수정 */
+	update: async (cohortId: number, params: UpdateCohortRequest) => {
+		const res = await http.put<CohortItem>(`v1/cohorts/${cohortId}`, { json: params });
+		return res;
+	},
+
+	/** DELETE /v1/cohorts/{cohortId} - 기수 삭제 */
+	delete: async (cohortId: number) => {
+		const res = await http.delete(`v1/cohorts/${cohortId}`);
 		return res;
 	},
 };

--- a/packages/api/src/cohort/types.ts
+++ b/packages/api/src/cohort/types.ts
@@ -1,1 +1,18 @@
 export type Cohort = string;
+
+export interface CohortItem {
+	cohortId: number;
+	cohortNumber: string;
+}
+
+export interface CohortListResponse {
+	cohorts: CohortItem[];
+}
+
+export interface CreateCohortRequest {
+	value: string;
+}
+
+export interface UpdateCohortRequest {
+	value: string;
+}


### PR DESCRIPTION
## Summary
- 권한관리 탭 placeholder를 멤버 목록 테이블로 교체 (overview API 연동)
- 통합 검색 필터 추가 (ID, 이름, 파트, 상태, 기수)
- 컬럼 헤더 클릭으로 오름차순/내림차순 정렬 기능
- 기수 ID → 기수명 매핑 표시, StatusBadge로 상태 시각화

## Test plan
- [ ] 권한관리 탭에서 멤버 목록이 정상 표시되는지 확인
- [ ] 검색 입력 시 ID, 이름, 파트, 상태, 기수로 필터링되는지 확인
- [ ] 각 컬럼 헤더 클릭 시 정렬이 토글되는지 확인
- [ ] 검색 결과 없을 때 빈 상태 메시지 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)