### PR TITLE
feat: Super Admin API 연동 (기수/권한 관리)

### DIFF
--- a/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
@@ -1,6 +1,8 @@
 'use client';
 
 import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import type { CohortItem } from '@dpm-core/api';
 import {
 	Button,
 	Dialog,
@@ -19,20 +21,18 @@ import {
 	toast,
 } from '@dpm-core/shared';
 
-interface CohortItem {
-	cohortId: number;
-	cohortNumber: string;
-}
-
-// TODO: API 연동 후 제거
-const MOCK_COHORTS: CohortItem[] = [
-	{ cohortId: 1, cohortNumber: '15기' },
-	{ cohortId: 2, cohortNumber: '16기' },
-	{ cohortId: 3, cohortNumber: '17기' },
-];
+import {
+	createCohortMutationOptions,
+	deleteCohortMutationOptions,
+	updateCohortMutationOptions,
+} from '@/remotes/mutations/cohort';
+import { COHORT_LIST_QUERY_KEY, getCohortListQuery } from '@/remotes/queries/cohort';
 
 export const CohortManagement = () => {
-	const [cohorts, setCohorts] = useState<CohortItem[]>(MOCK_COHORTS);
+	const queryClient = useQueryClient();
+	const { data: cohortsData, isLoading } = useQuery(getCohortListQuery);
+	const cohorts = cohortsData?.data.cohorts ?? [];
+
 	const [createDialogOpen, setCreateDialogOpen] = useState(false);
 	const [editDialogOpen, setEditDialogOpen] = useState(false);
 	const [deleteDialogOpen, setDeleteDialogOpen] = useState(false);
@@ -40,40 +40,66 @@ export const CohortManagement = () => {
 	const [editTarget, setEditTarget] = useState<CohortItem | null>(null);
 	const [deleteTarget, setDeleteTarget] = useState<CohortItem | null>(null);
 
+	const invalidateCohorts = () => {
+		queryClient.invalidateQueries({ queryKey: COHORT_LIST_QUERY_KEY });
+	};
+
+	const { mutate: createCohort, isPending: isCreatePending } = useMutation(
+		createCohortMutationOptions({
+			onSuccess: () => {
+				toast.success('기수가 생성되었습니다.');
+				invalidateCohorts();
+				setCreateDialogOpen(false);
+				setInputValue('');
+			},
+			onError: () => {
+				toast.error('기수 생성에 실패했습니다.');
+			},
+		}),
+	);
+
+	const { mutate: updateCohort, isPending: isUpdatePending } = useMutation(
+		updateCohortMutationOptions({
+			onSuccess: () => {
+				toast.success('기수가 수정되었습니다.');
+				invalidateCohorts();
+				setEditDialogOpen(false);
+				setEditTarget(null);
+				setInputValue('');
+			},
+			onError: () => {
+				toast.error('기수 수정에 실패했습니다.');
+			},
+		}),
+	);
+
+	const { mutate: deleteCohort, isPending: isDeletePending } = useMutation(
+		deleteCohortMutationOptions({
+			onSuccess: () => {
+				toast.success('기수가 삭제되었습니다.');
+				invalidateCohorts();
+				setDeleteDialogOpen(false);
+				setDeleteTarget(null);
+			},
+			onError: () => {
+				toast.error('기수 삭제에 실패했습니다.');
+			},
+		}),
+	);
+
 	const handleCreate = () => {
 		if (!inputValue.trim()) return;
-		// TODO: API 연동
-		const newCohort: CohortItem = {
-			cohortId: Math.max(0, ...cohorts.map((c) => c.cohortId)) + 1,
-			cohortNumber: inputValue.trim(),
-		};
-		setCohorts((prev) => [...prev, newCohort]);
-		setCreateDialogOpen(false);
-		setInputValue('');
-		toast.success('기수가 생성되었습니다.');
+		createCohort({ value: inputValue.trim() });
 	};
 
 	const handleEdit = () => {
 		if (!editTarget || !inputValue.trim()) return;
-		// TODO: API 연동
-		setCohorts((prev) =>
-			prev.map((c) =>
-				c.cohortId === editTarget.cohortId ? { ...c, cohortNumber: inputValue.trim() } : c,
-			),
-		);
-		setEditDialogOpen(false);
-		setEditTarget(null);
-		setInputValue('');
-		toast.success('기수가 수정되었습니다.');
+		updateCohort({ cohortId: editTarget.cohortId, params: { value: inputValue.trim() } });
 	};
 
 	const handleDelete = () => {
 		if (!deleteTarget) return;
-		// TODO: API 연동
-		setCohorts((prev) => prev.filter((c) => c.cohortId !== deleteTarget.cohortId));
-		setDeleteDialogOpen(false);
-		setDeleteTarget(null);
-		toast.success('기수가 삭제되었습니다.');
+		deleteCohort(deleteTarget.cohortId);
 	};
 
 	const openEditDialog = (item: CohortItem) => {
@@ -106,7 +132,11 @@ export const CohortManagement = () => {
 			</div>
 
 			{/* Table */}
-			{cohorts.length === 0 ? (
+			{isLoading ? (
+				<div className="flex min-h-[200px] w-full items-center justify-center py-12">
+					<p className="font-medium text-body1 text-label-assistive">기수 목록을 불러오는 중...</p>
+				</div>
+			) : cohorts.length === 0 ? (
 				<div className="flex min-h-[200px] w-full items-center justify-center py-12">
 					<p className="font-medium text-body1 text-label-assistive">등록된 기수가 없습니다</p>
 				</div>
@@ -161,7 +191,9 @@ export const CohortManagement = () => {
 				<DialogContent>
 					<DialogHeader>
 						<DialogTitle>기수 추가</DialogTitle>
-						<DialogDescription>새로운 기수를 생성합니다. 최신 기수 역할이 자동 생성됩니다.</DialogDescription>
+						<DialogDescription>
+							새로운 기수를 생성합니다. 최신 기수 역할이 자동 생성됩니다.
+						</DialogDescription>
 					</DialogHeader>
 					<input
 						type="text"
@@ -174,8 +206,8 @@ export const CohortManagement = () => {
 						<DialogClose asChild>
 							<Button variant="assistive">취소</Button>
 						</DialogClose>
-						<Button onClick={handleCreate} disabled={!inputValue.trim()}>
-							생성
+						<Button onClick={handleCreate} disabled={!inputValue.trim() || isCreatePending}>
+							{isCreatePending ? '생성 중...' : '생성'}
 						</Button>
 					</DialogFooter>
 				</DialogContent>
@@ -201,8 +233,8 @@ export const CohortManagement = () => {
 						<DialogClose asChild>
 							<Button variant="assistive">취소</Button>
 						</DialogClose>
-						<Button onClick={handleEdit} disabled={!inputValue.trim()}>
-							수정
+						<Button onClick={handleEdit} disabled={!inputValue.trim() || isUpdatePending}>
+							{isUpdatePending ? '수정 중...' : '수정'}
 						</Button>
 					</DialogFooter>
 				</DialogContent>
@@ -214,15 +246,16 @@ export const CohortManagement = () => {
 					<DialogHeader>
 						<DialogTitle>기수 삭제</DialogTitle>
 						<DialogDescription>
-							{deleteTarget?.cohortNumber} 기수를 정말 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다.
+							{deleteTarget?.cohortNumber} 기수를 정말 삭제하시겠습니까? 이 작업은 되돌릴 수
+							없습니다.
 						</DialogDescription>
 					</DialogHeader>
 					<DialogFooter>
 						<DialogClose asChild>
 							<Button variant="assistive">취소</Button>
 						</DialogClose>
-						<Button variant="secondary" onClick={handleDelete}>
-							삭제
+						<Button variant="secondary" onClick={handleDelete} disabled={isDeletePending}>
+							{isDeletePending ? '삭제 중...' : '삭제'}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/CohortManagement.tsx
@@ -12,6 +12,7 @@ import {
 	DialogFooter,
 	DialogHeader,
 	DialogTitle,
+	Skeleton,
 	Table,
 	TableBody,
 	TableCell,
@@ -133,8 +134,22 @@ export const CohortManagement = () => {
 
 			{/* Table */}
 			{isLoading ? (
-				<div className="flex min-h-[200px] w-full items-center justify-center py-12">
-					<p className="font-medium text-body1 text-label-assistive">기수 목록을 불러오는 중...</p>
+				<div className="flex w-full flex-col">
+					<div className="flex h-10 items-center gap-3 bg-background-strong px-3">
+						<Skeleton className="h-4 w-16" />
+						<Skeleton className="h-4 w-16" />
+						<Skeleton className="ml-auto h-4 w-12" />
+					</div>
+					{['sk-1', 'sk-2', 'sk-3'].map((key) => (
+						<div
+							key={key}
+							className="flex h-14 items-center gap-3 border-line-subtle border-b px-3"
+						>
+							<Skeleton className="h-4 w-10" />
+							<Skeleton className="h-4 w-20" />
+							<Skeleton className="ml-auto h-4 w-24" />
+						</div>
+					))}
 				</div>
 			) : cohorts.length === 0 ? (
 				<div className="flex min-h-[200px] w-full items-center justify-center py-12">

--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -20,6 +20,7 @@ import {
 	SelectItem,
 	SelectTrigger,
 	SelectValue,
+	Skeleton,
 	StatusBadge,
 	Table,
 	TableBody,
@@ -253,8 +254,28 @@ export const PermissionManagement = () => {
 			</div>
 			{/* Table */}
 			{membersLoading ? (
-				<div className="flex min-h-75 w-full items-center justify-center py-12">
-					<p className="font-medium text-body1 text-label-assistive">멤버 목록을 불러오는 중...</p>
+				<div className="flex w-full flex-col">
+					<div className="flex h-10 items-center gap-6 bg-background-strong px-3">
+						<Skeleton className="h-4 w-8" />
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="h-4 w-12" />
+						<Skeleton className="ml-auto h-4 w-12" />
+					</div>
+					{['sk-1', 'sk-2', 'sk-3', 'sk-4', 'sk-5'].map((key) => (
+						<div
+							key={key}
+							className="flex h-14 items-center gap-6 border-line-subtle border-b px-3"
+						>
+							<Skeleton className="h-4 w-8" />
+							<Skeleton className="h-4 w-20" />
+							<Skeleton className="h-4 w-12" />
+							<Skeleton className="h-4 w-16" />
+							<Skeleton className="h-4 w-16" />
+							<Skeleton className="ml-auto h-4 w-32" />
+						</div>
+					))}
 				</div>
 			) : filteredAndSortedMembers.length === 0 ? (
 				<div className="flex min-h-75 w-full items-center justify-center py-12">

--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -1,10 +1,24 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ArrowDownAZ, ArrowUpAZ } from 'lucide-react';
+import type { MemberOverviewItem } from '@dpm-core/api';
 import {
+	Button,
+	Dialog,
+	DialogClose,
+	DialogContent,
+	DialogDescription,
+	DialogFooter,
+	DialogHeader,
+	DialogTitle,
 	SearchInputOutlined,
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
 	StatusBadge,
 	Table,
 	TableBody,
@@ -12,13 +26,25 @@ import {
 	TableHead,
 	TableHeader,
 	TableRow,
+	toast,
 } from '@dpm-core/shared';
 
+import {
+	updateMemberRoleMutationOptions,
+	updateMemberStatusMutationOptions,
+} from '@/remotes/mutations/member';
 import { getCohortListQuery } from '@/remotes/queries/cohort';
 import { getMembersOverviewQuery } from '@/remotes/queries/member';
 
+type ActionType = 'role' | 'status';
+
 type SortKey = 'memberId' | 'name' | 'cohortId' | 'part' | 'status';
 type SortOrder = 'asc' | 'desc';
+
+const STATUS_OPTIONS = [
+	{ value: 'PENDING', label: 'PENDING' },
+	{ value: 'ACTIVE', label: 'ACTIVE' },
+] as const;
 
 const SORT_COLUMNS = [
 	{ key: 'memberId', label: 'ID' },
@@ -44,6 +70,8 @@ const statusBadgeStatus = (status: string) => {
 };
 
 export const PermissionManagement = () => {
+	const queryClient = useQueryClient();
+
 	const { data: membersData, isLoading: membersLoading } = useQuery(getMembersOverviewQuery());
 	const { data: cohortsData } = useQuery(getCohortListQuery);
 
@@ -54,6 +82,11 @@ export const PermissionManagement = () => {
 	const [searchQuery, setSearchQuery] = useState('');
 	const [sortKey, setSortKey] = useState<SortKey>('memberId');
 	const [sortOrder, setSortOrder] = useState<SortOrder>('asc');
+
+	const [dialogOpen, setDialogOpen] = useState(false);
+	const [actionType, setActionType] = useState<ActionType>('role');
+	const [targetMember, setTargetMember] = useState<MemberOverviewItem | null>(null);
+	const [selectedStatus, setSelectedStatus] = useState<'PENDING' | 'ACTIVE'>('ACTIVE');
 
 	const handleSort = (key: SortKey) => {
 		if (sortKey === key) {
@@ -98,6 +131,89 @@ export const PermissionManagement = () => {
 			}
 		});
 	}, [members, searchQuery, sortKey, sortOrder, cohortMap]);
+
+	const invalidateMembers = () => {
+		setTimeout(() => {
+			queryClient.invalidateQueries({ queryKey: ['members-overview'] });
+		}, 500);
+	};
+
+	const { mutate: updateRole, isPending: isRolePending } = useMutation(
+		updateMemberRoleMutationOptions({
+			onSuccess: () => {
+				toast.success('역할이 변경되었습니다.');
+				invalidateMembers();
+				setDialogOpen(false);
+			},
+			onError: () => {
+				toast.error('역할 변경에 실패했습니다.');
+			},
+		}),
+	);
+
+	const { mutate: updateStatus, isPending: isStatusPending } = useMutation(
+		updateMemberStatusMutationOptions({
+			onSuccess: () => {
+				toast.success('멤버 상태가 변경되었습니다.');
+				invalidateMembers();
+				setDialogOpen(false);
+			},
+			onError: () => {
+				toast.error('상태 변경에 실패했습니다.');
+			},
+		}),
+	);
+
+	const isPending = isRolePending || isStatusPending;
+
+	const openDialog = (member: MemberOverviewItem, action: ActionType) => {
+		setTargetMember(member);
+		setActionType(action);
+		setSelectedStatus('ACTIVE');
+		setDialogOpen(true);
+	};
+
+	const handleConfirm = () => {
+		if (!targetMember) return;
+
+		switch (actionType) {
+			case 'role': {
+				const cohortNumber = cohortMap.get(targetMember.cohortId) ?? String(targetMember.cohortId);
+				updateRole({
+					memberId: targetMember.memberId,
+					isAdmin: !targetMember.isAdmin,
+					cohort: cohortNumber,
+				});
+				break;
+			}
+			case 'status':
+				updateStatus({
+					memberId: String(targetMember.memberId),
+					memberStatus: selectedStatus,
+				});
+				break;
+		}
+	};
+
+	const getDialogConfig = () => {
+		const targetRole = targetMember?.isAdmin ? 'DEEPER' : 'ORGANIZER';
+		switch (actionType) {
+			case 'role':
+				return {
+					title: `${targetRole} 역할 변환`,
+					description: `${targetMember?.name}(ID: ${targetMember?.memberId}) 멤버를 ${targetRole}로 변환하시겠습니까?`,
+					confirmLabel: '변환',
+				};
+			case 'status':
+				return {
+					title: '멤버 상태 변경',
+					description: `${targetMember?.name}(ID: ${targetMember?.memberId}) 멤버의 상태를 변경합니다.`,
+					confirmLabel: '변경',
+				};
+		}
+	};
+
+	const dialogConfig = getDialogConfig();
 
 	return (
 		<div className="flex w-full flex-col gap-6">
@@ -174,14 +290,64 @@ export const PermissionManagement = () => {
 								<TableCell className="px-3">
 									<StatusBadge status={statusBadgeStatus(m.status)}>{m.status}</StatusBadge>
 								</TableCell>
-								<TableCell className="px-3 text-right font-medium text-body2 text-label-assistive">
-									API 연동 후 추가 예정
+								<TableCell className="flex items-center justify-end gap-2 px-3">
+									<button
+										type="button"
+										className="cursor-pointer rounded-md px-3 py-1.5 font-medium text-body2 text-label-normal hover:bg-background-strong"
+										onClick={() => openDialog(m, 'role')}
+									>
+										{m.isAdmin ? 'DEEPER 변환' : 'ORGANIZER 변환'}
+									</button>
+									<button
+										type="button"
+										className="cursor-pointer rounded-md px-3 py-1.5 font-medium text-body2 text-label-normal hover:bg-background-strong"
+										onClick={() => openDialog(m, 'status')}
+									>
+										상태 변경
+									</button>
 								</TableCell>
 							</TableRow>
 						))}
 					</TableBody>
 				</Table>
 			)}
+
+			{/* Action Dialog */}
+			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
+				<DialogContent>
+					<DialogHeader>
+						<DialogTitle>{dialogConfig.title}</DialogTitle>
+						<DialogDescription>{dialogConfig.description}</DialogDescription>
+					</DialogHeader>
+
+					{actionType === 'status' && (
+						<Select
+							value={selectedStatus}
+							onValueChange={(value) => setSelectedStatus(value as 'PENDING' | 'ACTIVE')}
+						>
+							<SelectTrigger className="w-full">
+								<SelectValue placeholder="상태 선택" />
+							</SelectTrigger>
+							<SelectContent>
+								{STATUS_OPTIONS.map((opt) => (
+									<SelectItem key={opt.value} value={opt.value}>
+										{opt.label}
+									</SelectItem>
+								))}
+							</SelectContent>
+						</Select>
+					)}
+
+					<DialogFooter>
+						<DialogClose asChild>
+							<Button variant="assistive">취소</Button>
+						</DialogClose>
+						<Button onClick={handleConfirm} disabled={isPending}>
+							{isPending ? '처리 중...' : dialogConfig.confirmLabel}
+						</Button>
+					</DialogFooter>
+				</DialogContent>
+			</Dialog>
 		</div>
 	);
 };

--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -2,6 +2,7 @@
 
 import { useMemo, useState } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { HTTPError } from 'ky';
 import { ArrowDownAZ, ArrowUpAZ } from 'lucide-react';
 import type { MemberOverviewItem } from '@dpm-core/api';
 import {
@@ -54,6 +55,18 @@ const SORT_COLUMNS = [
 	{ key: 'status', label: '상태' },
 ] as const;
 
+const getErrorMessage = async (error: Error, fallback: string) => {
+	if (error instanceof HTTPError) {
+		try {
+			const body = await error.response.json();
+			if (body?.message) return body.message as string;
+		} catch {
+			// 파싱 실패 시 fallback 사용
+		}
+	}
+	return fallback;
+};
+
 const statusBadgeStatus = (status: string) => {
 	switch (status) {
 		case 'ACTIVE':
@@ -72,7 +85,11 @@ const statusBadgeStatus = (status: string) => {
 export const PermissionManagement = () => {
 	const queryClient = useQueryClient();
 
-	const { data: membersData, isLoading: membersLoading } = useQuery(getMembersOverviewQuery());
+	const {
+		data: membersData,
+		isLoading: membersLoading,
+		isFetching: membersFething,
+	} = useQuery(getMembersOverviewQuery());
 	const { data: cohortsData } = useQuery(getCohortListQuery);
 
 	const members = membersData?.data.members ?? [];
@@ -133,20 +150,19 @@ export const PermissionManagement = () => {
 	}, [members, searchQuery, sortKey, sortOrder, cohortMap]);
 
 	const invalidateMembers = () => {
-		setTimeout(() => {
-			queryClient.invalidateQueries({ queryKey: ['members-overview'] });
-		}, 500);
+		queryClient.invalidateQueries({ queryKey: ['members-overview'] });
 	};
 
 	const { mutate: updateRole, isPending: isRolePending } = useMutation(
 		updateMemberRoleMutationOptions({
 			onSuccess: () => {
+				setDialogOpen(false);
 				toast.success('역할이 변경되었습니다.');
 				invalidateMembers();
-				setDialogOpen(false);
 			},
-			onError: () => {
-				toast.error('역할 변경에 실패했습니다.');
+			onError: async (error) => {
+				const message = await getErrorMessage(error, '역할 변경에 실패했습니다.');
+				toast.error(message);
 			},
 		}),
 	);
@@ -154,12 +170,13 @@ export const PermissionManagement = () => {
 	const { mutate: updateStatus, isPending: isStatusPending } = useMutation(
 		updateMemberStatusMutationOptions({
 			onSuccess: () => {
+				setDialogOpen(false);
 				toast.success('멤버 상태가 변경되었습니다.');
 				invalidateMembers();
-				setDialogOpen(false);
 			},
-			onError: () => {
-				toast.error('상태 변경에 실패했습니다.');
+			onError: async (error) => {
+				const message = await getErrorMessage(error, '상태 변경에 실패했습니다.');
+				toast.error(message);
 			},
 		}),
 	);
@@ -234,14 +251,13 @@ export const PermissionManagement = () => {
 					/>
 				</div>
 			</div>
-
 			{/* Table */}
 			{membersLoading ? (
-				<div className="flex min-h-[300px] w-full items-center justify-center py-12">
+				<div className="flex min-h-75 w-full items-center justify-center py-12">
 					<p className="font-medium text-body1 text-label-assistive">멤버 목록을 불러오는 중...</p>
 				</div>
 			) : filteredAndSortedMembers.length === 0 ? (
-				<div className="flex min-h-[300px] w-full items-center justify-center py-12">
+				<div className="flex min-h-75 w-full items-center justify-center py-12">
 					<p className="font-medium text-body1 text-label-assistive">
 						{searchQuery ? '검색 결과가 없습니다' : '등록된 멤버가 없습니다'}
 					</p>
@@ -267,14 +283,29 @@ export const PermissionManagement = () => {
 									</button>
 								</TableHead>
 							))}
-							<TableHead className="w-[200px] px-3 text-right font-medium text-body2 text-label-subtle">
+							<TableHead className="w-50 px-6 font-medium text-body2 text-label-subtle">
 								관리
 							</TableHead>
 						</TableRow>
 					</TableHeader>
+					{membersFething && !membersLoading && (
+						<TableBody>
+							<TableRow className="h-0 border-0 p-0 hover:bg-transparent">
+								<TableCell colSpan={6} className="h-0 border-0 p-0">
+									<div className="h-0.5 w-full overflow-hidden bg-background-strong">
+										<div
+											className="h-full w-1/3 bg-primary-normal"
+											style={{ animation: 'progress 1s ease-in-out infinite' }}
+										/>
+									</div>
+									<style>{`@keyframes progress { 0% { transform: translateX(-100%); } 100% { transform: translateX(400%); } }`}</style>
+								</TableCell>
+							</TableRow>
+						</TableBody>
+					)}
 					<TableBody>
 						{filteredAndSortedMembers.map((m) => (
-							<TableRow key={m.memberId} className="h-[56px] border-line-subtle">
+							<TableRow key={m.memberId} className="h-12 border-line-subtle">
 								<TableCell className="px-3 font-medium text-body1 text-label-normal">
 									{m.memberId}
 								</TableCell>
@@ -311,7 +342,6 @@ export const PermissionManagement = () => {
 					</TableBody>
 				</Table>
 			)}
-
 			{/* Action Dialog */}
 			<Dialog open={dialogOpen} onOpenChange={setDialogOpen}>
 				<DialogContent>
@@ -348,6 +378,7 @@ export const PermissionManagement = () => {
 					</DialogFooter>
 				</DialogContent>
 			</Dialog>
+			;
 		</div>
 	);
 };

--- a/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import type { MemberOverviewItem } from '@dpm-core/api';
 import {
 	Button,
 	Dialog,
@@ -11,24 +13,63 @@ import {
 	DialogHeader,
 	DialogTitle,
 	SearchInputOutlined,
+	StatusBadge,
+	Table,
+	TableBody,
+	TableCell,
+	TableHead,
+	TableHeader,
+	TableRow,
 	toast,
 } from '@dpm-core/shared';
 
+import { getMembersOverviewQuery } from '@/remotes/queries/member';
+
+const statusBadgeStatus = (status: string) => {
+	switch (status) {
+		case 'ACTIVE':
+			return 'success';
+		case 'PENDING':
+			return 'pending';
+		case 'INACTIVE':
+			return 'warning';
+		case 'WITHDRAWN':
+			return 'error';
+		default:
+			return 'default';
+	}
+};
+
 export const UserHardDelete = () => {
+	const { data: membersData } = useQuery(getMembersOverviewQuery());
+	const members = membersData?.data.members ?? [];
+
 	const [searchQuery, setSearchQuery] = useState('');
 	const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
-	const [targetUser, setTargetUser] = useState<string | null>(null);
+	const [targetMember, setTargetMember] = useState<MemberOverviewItem | null>(null);
 
-	const handleSearch = () => {
-		// TODO: 유저 검색 API 연동
-		toast.info('유저 검색 API 연동 후 구현 예정');
+	const searchResults = useMemo(() => {
+		const query = searchQuery.trim().toLowerCase();
+		if (!query) return [];
+
+		return members.filter(
+			(m) =>
+				m.name.toLowerCase().includes(query) ||
+				String(m.memberId).includes(query) ||
+				(m.email && m.email.toLowerCase().includes(query)),
+		);
+	}, [members, searchQuery]);
+
+	const openConfirmDialog = (member: MemberOverviewItem) => {
+		setTargetMember(member);
+		setConfirmDialogOpen(true);
 	};
 
 	const handleConfirmDelete = () => {
-		// TODO: member_oauth 값과 이메일 변경하여 하드 딜리트 처리
+		// TODO: 하드 딜리트 API 연동
 		toast.info('유저 삭제 API 연동 후 구현 예정');
 		setConfirmDialogOpen(false);
-		setTargetUser(null);
+		setTargetMember(null);
 	};
 
 	return (
@@ -41,24 +82,68 @@ export const UserHardDelete = () => {
 			</div>
 
 			{/* Search */}
-			<div className="flex items-center gap-3">
-				<div className="w-[400px]">
-					<SearchInputOutlined
-						placeholder="유저 이름 또는 이메일 검색"
-						value={searchQuery}
-						onChange={(e) => setSearchQuery(e.target.value)}
-						className="h-10 w-full"
-					/>
-				</div>
-				<Button onClick={handleSearch}>검색</Button>
+			<div className="w-[400px]">
+				<SearchInputOutlined
+					placeholder="유저 ID, 이름 또는 이메일 검색"
+					value={searchQuery}
+					onChange={(e) => setSearchQuery(e.target.value)}
+					className="h-10 w-full"
+				/>
 			</div>
 
-			{/* Placeholder */}
-			<div className="flex min-h-[200px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
-				<p className="font-medium text-body1 text-label-assistive">
-					유저를 검색하여 삭제 대상을 선택하세요
-				</p>
-			</div>
+			{/* Results */}
+			{!searchQuery.trim() ? (
+				<div className="flex min-h-[200px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
+					<p className="font-medium text-body1 text-label-assistive">
+						유저를 검색하여 삭제 대상을 선택하세요
+					</p>
+				</div>
+			) : searchResults.length === 0 ? (
+				<div className="flex min-h-[200px] w-full items-center justify-center rounded-lg border border-line-normal py-12">
+					<p className="font-medium text-body1 text-label-assistive">검색 결과가 없습니다</p>
+				</div>
+			) : (
+				<Table className="w-full">
+					<TableHeader>
+						<TableRow className="h-10 border-0 bg-background-strong hover:bg-background-strong">
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">ID</TableHead>
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">이름</TableHead>
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">파트</TableHead>
+							<TableHead className="px-3 font-medium text-body2 text-label-subtle">상태</TableHead>
+							<TableHead className="w-[100px] px-3 text-right font-medium text-body2 text-label-subtle">
+								관리
+							</TableHead>
+						</TableRow>
+					</TableHeader>
+					<TableBody>
+						{searchResults.map((m) => (
+							<TableRow key={m.memberId} className="h-[56px] border-line-subtle">
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.memberId}
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.name}
+								</TableCell>
+								<TableCell className="px-3 font-medium text-body1 text-label-normal">
+									{m.part}
+								</TableCell>
+								<TableCell className="px-3">
+									<StatusBadge status={statusBadgeStatus(m.status)}>{m.status}</StatusBadge>
+								</TableCell>
+								<TableCell className="px-3 text-right">
+									<button
+										type="button"
+										className="cursor-pointer rounded-md px-3 py-1.5 font-medium text-body2 text-status-danger hover:bg-red-50"
+										onClick={() => openConfirmDialog(m)}
+									>
+										삭제
+									</button>
+								</TableCell>
+							</TableRow>
+						))}
+					</TableBody>
+				</Table>
+			)}
 
 			{/* Confirm Dialog */}
 			<Dialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
@@ -66,7 +151,8 @@ export const UserHardDelete = () => {
 					<DialogHeader>
 						<DialogTitle>유저 삭제 확인</DialogTitle>
 						<DialogDescription>
-							{targetUser} 유저를 하드 딜리트 처리하시겠습니까?
+							{targetMember?.name}(ID: {targetMember?.memberId}) 유저를 하드 딜리트
+							처리하시겠습니까?
 							<br />
 							member_oauth 값과 이메일이 변경되며, 이 작업은 되돌릴 수 없습니다.
 						</DialogDescription>

--- a/apps/admin/remotes/mutations/member.ts
+++ b/apps/admin/remotes/mutations/member.ts
@@ -1,5 +1,11 @@
 import { type MutationOptions, mutationOptions } from '@tanstack/react-query';
-import type { MemberStatus, Part } from '@dpm-core/api';
+import type {
+	InitCohortMemberParams,
+	MemberStatus,
+	Part,
+	UpdateMemberRoleRequest,
+	UpdateMemberStatusRequest,
+} from '@dpm-core/api';
 import { member } from '@dpm-core/api';
 
 type WithdrawMutationOptions = MutationOptions;
@@ -63,5 +69,59 @@ export const approveWhitelistMutationOptions = (
 		mutationKey: ['whitelist'],
 		mutationFn: (params: ApproveWhitelistParams) =>
 			member.approveWhitelist({ members: params.members }),
+		...options,
+	});
+
+/** PATCH /v1/roles/members/{memberId} - 멤버 역할 변경 (isAdmin: true=ORGANIZER, false=DEEPER) */
+export interface UpdateMemberRoleParams {
+	memberId: number;
+	isAdmin: boolean;
+	cohort: string;
+}
+
+export const updateMemberRoleMutationOptions = (
+	options?: MutationOptions<
+		Awaited<ReturnType<typeof member.updateMemberRole>>,
+		Error,
+		UpdateMemberRoleParams
+	>,
+) =>
+	mutationOptions({
+		mutationKey: ['members', 'role'],
+		mutationFn: (params: UpdateMemberRoleParams) =>
+			member.updateMemberRole(params.memberId, {
+				isAdmin: params.isAdmin,
+				cohort: params.cohort,
+			}),
+		...options,
+	});
+
+/** PATCH /v1/members/status - 멤버 상태 변경 */
+export const updateMemberStatusMutationOptions = (
+	options?: MutationOptions<
+		Awaited<ReturnType<typeof member.updateMemberStatus>>,
+		Error,
+		UpdateMemberStatusRequest
+	>,
+) =>
+	mutationOptions({
+		mutationKey: ['members', 'status'],
+		mutationFn: (params: UpdateMemberStatusRequest) =>
+			member.updateMemberStatus(params),
+		...options,
+	});
+
+/** POST /v1/members/authority/cohort/init/{cohortId}/{memberId} - 신규 기수 참여 회원 init */
+export const initCohortMemberMutationOptions = (
+	options?: MutationOptions<
+		Awaited<ReturnType<typeof member.initCohortMember>>,
+		Error,
+		InitCohortMemberParams
+	>,
+) =>
+	mutationOptions({
+		mutationKey: ['members', 'authority', 'cohort', 'init'],
+		mutationFn: (params: InitCohortMemberParams) =>
+			member.initCohortMember(params),
 		...options,
 	});

--- a/packages/api/src/member/remote.ts
+++ b/packages/api/src/member/remote.ts
@@ -3,8 +3,11 @@ import type {
 	ApproveWhitelistForSignupRequest,
 	ApproveWhitelistRequest,
 	ApproveWhitelistResponse,
+	InitCohortMemberParams,
 	Member,
 	MembersOverviewResponse,
+	UpdateMemberRoleRequest,
+	UpdateMemberStatusRequest,
 	UpdateMembersInitRequest,
 	UpdateMembersInitResponse,
 } from './types';
@@ -51,6 +54,30 @@ export const member = {
 		const res = await http.patch<ApproveWhitelistResponse>('v1/members/whitelist', {
 			json: params,
 		});
+		return res;
+	},
+
+	/** PATCH /v1/roles/members/{memberId} - 멤버 기수별 역할 변경 (isAdmin: true=ORGANIZER, false=DEEPER) */
+	updateMemberRole: async (memberId: number, params: UpdateMemberRoleRequest) => {
+		const res = await http.patch(`v1/roles/members/${memberId}`, {
+			json: params,
+		});
+		return res;
+	},
+
+	/** PATCH /v1/members/status - 멤버 상태 변경 */
+	updateMemberStatus: async (params: UpdateMemberStatusRequest) => {
+		const res = await http.patch('v1/members/status', {
+			json: params,
+		});
+		return res;
+	},
+
+	/** POST /v1/members/authority/cohort/init/{cohortId}/{memberId} - 신규 기수 참여 회원 init */
+	initCohortMember: async (params: InitCohortMemberParams) => {
+		const res = await http.post(
+			`v1/members/authority/cohort/init/${params.cohortId}/${params.memberId}`,
+		);
 		return res;
 	},
 };

--- a/packages/api/src/member/types.ts
+++ b/packages/api/src/member/types.ts
@@ -13,6 +13,7 @@ export interface MemberOverviewItem {
 	name: string;
 	email?: string;
 	teamName: string;
+	isAdmin: boolean;
 	status: MemberStatus;
 	part: MemberOverviewPart;
 }
@@ -68,4 +69,22 @@ export interface Member {
 	teamNumber: number;
 	isAdmin: boolean;
 	status: MemberStatus;
+}
+
+/** PATCH /v1/roles/members/{memberId} - 멤버 기수별 역할 변경 */
+export interface UpdateMemberRoleRequest {
+	isAdmin: boolean;
+	cohort: string;
+}
+
+/** PATCH /v1/members/status - 멤버 상태 변경 */
+export interface UpdateMemberStatusRequest {
+	memberId: string;
+	memberStatus: 'PENDING' | 'ACTIVE';
+}
+
+/** POST /v1/members/authority/cohort/init/{cohortId}/{memberId} - 신규 기수 참여 회원 init */
+export interface InitCohortMemberParams {
+	cohortId: number;
+	memberId: number;
 }


### PR DESCRIPTION
## Summary
- 기수 관리: mock 데이터 → cohort CRUD API 연동 (생성/수정/삭제 + 목록 조회)
- 권한 관리: 멤버 역할 변경 API 연동 (`PATCH /v1/roles/members/{memberId}`)
  - `isAdmin` 상태에 따라 ORGANIZER ↔ DEEPER 변환 버튼 분기
- 권한 관리: 멤버 상태 변경 API 연동 (`PATCH /v1/members/status`)
- `MemberOverviewItem` 타입에 `isAdmin` 필드 추가

## Test plan
- [ ] 기수 관리 탭에서 기수 목록 조회 확인
- [ ] 기수 추가/수정/삭제 동작 확인
- [ ] 권한 관리 탭에서 ORGANIZER/DEEPER 변환 버튼 분기 확인
- [ ] 역할 변환 및 상태 변경 API 호출 확인
- [ ] 각 mutation 성공 후 목록 갱신 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)