### PR TITLE
feat: 유저 하드 딜리트 API 연동

### DIFF
--- a/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/PermissionManagement.tsx
@@ -46,6 +46,7 @@ type SortOrder = 'asc' | 'desc';
 const STATUS_OPTIONS = [
 	{ value: 'PENDING', label: 'PENDING' },
 	{ value: 'ACTIVE', label: 'ACTIVE' },
+	{ value: 'INACTIVE', label: 'INACTIVE' },
 ] as const;
 
 const SORT_COLUMNS = [
@@ -104,7 +105,7 @@ export const PermissionManagement = () => {
 	const [dialogOpen, setDialogOpen] = useState(false);
 	const [actionType, setActionType] = useState<ActionType>('role');
 	const [targetMember, setTargetMember] = useState<MemberOverviewItem | null>(null);
-	const [selectedStatus, setSelectedStatus] = useState<'PENDING' | 'ACTIVE'>('ACTIVE');
+	const [selectedStatus, setSelectedStatus] = useState<'PENDING' | 'ACTIVE' | 'INACTIVE'>('ACTIVE');
 
 	const handleSort = (key: SortKey) => {
 		if (sortKey === key) {
@@ -374,7 +375,7 @@ export const PermissionManagement = () => {
 					{actionType === 'status' && (
 						<Select
 							value={selectedStatus}
-							onValueChange={(value) => setSelectedStatus(value as 'PENDING' | 'ACTIVE')}
+							onValueChange={(value) => setSelectedStatus(value as 'PENDING' | 'ACTIVE' | 'INACTIVE')}
 						>
 							<SelectTrigger className="w-full">
 								<SelectValue placeholder="상태 선택" />

--- a/apps/admin/app/(auth)/super-admin/_components/ScrollToTop.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/ScrollToTop.tsx
@@ -1,0 +1,36 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { ChevronUp } from 'lucide-react';
+import { cn } from '@dpm-core/shared';
+
+export const ScrollToTop = () => {
+	const [visible, setVisible] = useState(false);
+
+	useEffect(() => {
+		const handleScroll = () => {
+			setVisible(window.scrollY > 300);
+		};
+
+		window.addEventListener('scroll', handleScroll);
+		return () => window.removeEventListener('scroll', handleScroll);
+	}, []);
+
+	const scrollToTop = () => {
+		window.scrollTo({ top: 0, behavior: 'smooth' });
+	};
+
+	return (
+		<button
+			type="button"
+			onClick={scrollToTop}
+			className={cn(
+				'fixed right-8 bottom-8 z-50 flex size-10 cursor-pointer items-center justify-center rounded-full bg-primary-normal text-white shadow-lg transition-all hover:bg-primary-strong',
+				visible ? 'translate-y-0 opacity-100' : 'pointer-events-none translate-y-4 opacity-0',
+			)}
+			aria-label="맨 위로 스크롤"
+		>
+			<ChevronUp className="size-5" />
+		</button>
+	);
+};

--- a/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
+++ b/apps/admin/app/(auth)/super-admin/_components/UserHardDelete.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
-import { useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import type { MemberOverviewItem } from '@dpm-core/api';
 import {
 	Button,
@@ -23,6 +23,7 @@ import {
 	toast,
 } from '@dpm-core/shared';
 
+import { hardDeleteMemberMutationOptions } from '@/remotes/mutations/member';
 import { getMembersOverviewQuery } from '@/remotes/queries/member';
 
 const statusBadgeStatus = (status: string) => {
@@ -41,12 +42,27 @@ const statusBadgeStatus = (status: string) => {
 };
 
 export const UserHardDelete = () => {
+	const queryClient = useQueryClient();
 	const { data: membersData } = useQuery(getMembersOverviewQuery());
 	const members = membersData?.data.members ?? [];
 
 	const [searchQuery, setSearchQuery] = useState('');
 	const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
 	const [targetMember, setTargetMember] = useState<MemberOverviewItem | null>(null);
+
+	const { mutate: hardDeleteMember, isPending } = useMutation(
+		hardDeleteMemberMutationOptions({
+			onSuccess: () => {
+				toast.success('멤버가 삭제되었습니다.');
+				queryClient.invalidateQueries({ queryKey: ['members-overview'] });
+				setConfirmDialogOpen(false);
+				setTargetMember(null);
+			},
+			onError: (error) => {
+				toast.error(error.message || '멤버 삭제에 실패했습니다.');
+			},
+		}),
+	);
 
 	const searchResults = useMemo(() => {
 		const query = searchQuery.trim().toLowerCase();
@@ -66,10 +82,8 @@ export const UserHardDelete = () => {
 	};
 
 	const handleConfirmDelete = () => {
-		// TODO: 하드 딜리트 API 연동
-		toast.info('유저 삭제 API 연동 후 구현 예정');
-		setConfirmDialogOpen(false);
-		setTargetMember(null);
+		if (!targetMember) return;
+		hardDeleteMember(targetMember.memberId);
 	};
 
 	return (
@@ -161,8 +175,8 @@ export const UserHardDelete = () => {
 						<DialogClose asChild>
 							<Button variant="assistive">취소</Button>
 						</DialogClose>
-						<Button variant="secondary" onClick={handleConfirmDelete}>
-							삭제
+						<Button variant="secondary" onClick={handleConfirmDelete} disabled={isPending}>
+							{isPending ? '삭제 중...' : '삭제'}
 						</Button>
 					</DialogFooter>
 				</DialogContent>

--- a/apps/admin/app/(auth)/super-admin/page.tsx
+++ b/apps/admin/app/(auth)/super-admin/page.tsx
@@ -2,6 +2,7 @@ import { AppLayout } from '@dpm-core/shared';
 
 import { AppHeader } from '@/components/app-header';
 
+import { ScrollToTop } from './_components/ScrollToTop';
 import { SuperAdminTabs } from './_components/SuperAdminTabs';
 
 export default function SuperAdminPage() {
@@ -9,6 +10,7 @@ export default function SuperAdminPage() {
 		<AppLayout className="flex flex-col bg-background-normal">
 			<AppHeader title="Super Admin" />
 			<SuperAdminTabs />
+			<ScrollToTop />
 		</AppLayout>
 	);
 }

--- a/apps/admin/remotes/mutations/member.ts
+++ b/apps/admin/remotes/mutations/member.ts
@@ -106,8 +106,7 @@ export const updateMemberStatusMutationOptions = (
 ) =>
 	mutationOptions({
 		mutationKey: ['members', 'status'],
-		mutationFn: (params: UpdateMemberStatusRequest) =>
-			member.updateMemberStatus(params),
+		mutationFn: (params: UpdateMemberStatusRequest) => member.updateMemberStatus(params),
 		...options,
 	});
 
@@ -121,7 +120,16 @@ export const initCohortMemberMutationOptions = (
 ) =>
 	mutationOptions({
 		mutationKey: ['members', 'authority', 'cohort', 'init'],
-		mutationFn: (params: InitCohortMemberParams) =>
-			member.initCohortMember(params),
+		mutationFn: (params: InitCohortMemberParams) => member.initCohortMember(params),
+		...options,
+	});
+
+/** DELETE /v1/members/{memberId}/hard-delete - 멤버 하드 삭제 */
+export const hardDeleteMemberMutationOptions = (
+	options?: MutationOptions<Awaited<ReturnType<typeof member.hardDeleteMember>>, Error, number>,
+) =>
+	mutationOptions({
+		mutationKey: ['members', 'hard-delete'],
+		mutationFn: (memberId: number) => member.hardDeleteMember(memberId),
 		...options,
 	});

--- a/packages/api/src/member/remote.ts
+++ b/packages/api/src/member/remote.ts
@@ -20,8 +20,7 @@ export const member = {
 
 	/** GET /v1/members/overview - latest 파라미터 (이번 기수만 보기, false면 미전송) */
 	getMembersOverview: async (params?: { latest?: boolean }) => {
-		const searchParams =
-			params?.latest === true ? { latest: 'true' } : undefined;
+		const searchParams = params?.latest === true ? { latest: 'true' } : undefined;
 		const res = await http.get<MembersOverviewResponse>('v1/members/overview', {
 			searchParams,
 		});
@@ -78,6 +77,12 @@ export const member = {
 		const res = await http.post(
 			`v1/members/authority/cohort/init/${params.cohortId}/${params.memberId}`,
 		);
+		return res;
+	},
+
+	/** DELETE /v1/members/{memberId}/hard-delete - 멤버 하드 삭제 */
+	hardDeleteMember: async (memberId: number) => {
+		const res = await http.delete(`v1/members/${memberId}/hard-delete`);
 		return res;
 	},
 };

--- a/packages/api/src/member/types.ts
+++ b/packages/api/src/member/types.ts
@@ -80,7 +80,7 @@ export interface UpdateMemberRoleRequest {
 /** PATCH /v1/members/status - 멤버 상태 변경 */
 export interface UpdateMemberStatusRequest {
 	memberId: string;
-	memberStatus: 'PENDING' | 'ACTIVE';
+	memberStatus: 'PENDING' | 'ACTIVE' | 'INACTIVE';
 }
 
 /** POST /v1/members/authority/cohort/init/{cohortId}/{memberId} - 신규 기수 참여 회원 init */


### PR DESCRIPTION
## Summary
- \`DELETE /v1/members/{memberId}/hard-delete\` API 연동
- UserHardDelete 컴포넌트에서 검색 후 실제로 멤버 삭제 가능하도록 구현
- 성공 시 멤버 목록 자동 갱신, 실패 시 서버 에러 메시지 toast 표시

## Test plan
- [ ] 유저 삭제 탭에서 멤버 검색
- [ ] 삭제 버튼 클릭 후 확인 다이얼로그 표시
- [ ] 삭제 확인 시 API 호출 + 목록 갱신
- [ ] 실패 시 에러 메시지 표시

🤖 Generated with [Claude Code](https://claude.com/claude-code)