### PR TITLE
fix: 지각 시간대에도 출석 배너 표시

### DIFF
--- a/apps/client/app/(home)/_components/home-attendance-banner.tsx
+++ b/apps/client/app/(home)/_components/home-attendance-banner.tsx
@@ -18,7 +18,11 @@ export const HomeCheckAttendanceBanner = () => {
 
 	if (
 		!attendanceSession ||
-		!showAttendanceBanner(attendanceSession.attendanceStart, attendanceSession.lateStart)
+		!showAttendanceBanner(
+			attendanceSession.attendanceStart,
+			attendanceSession.lateStart,
+			attendanceSession.absentStart,
+		)
 	) {
 		return null;
 	}

--- a/apps/client/lib/attendance/banner.ts
+++ b/apps/client/lib/attendance/banner.ts
@@ -1,9 +1,13 @@
 import dayjs from 'dayjs';
 
-export const showAttendanceBanner = (attendanceStart: string, lateStart: string) => {
-	if (!attendanceStart || !lateStart) {
+export const showAttendanceBanner = (
+	attendanceStart: string,
+	lateStart: string,
+	absentStart: string,
+) => {
+	if (!attendanceStart || !lateStart || !absentStart) {
 		return false;
 	}
 	const now = dayjs();
-	return now.isAfter(dayjs(attendanceStart)) && now.isBefore(dayjs(lateStart));
+	return now.isAfter(dayjs(attendanceStart)) && now.isBefore(dayjs(absentStart));
 };


### PR DESCRIPTION
## Summary
- 출석 배너 노출 범위가 `lateStart`까지만 허용되어, 지각 시간대(`lateStart` ~ `absentStart`)에 출석 버튼이 사라지는 버그 수정
- `showAttendanceBanner` 함수에 `absentStart` 파라미터 추가
- 배너 노출 조건을 `attendanceStart` ~ `absentStart`로 확장

## Test plan
- [ ] 출석 가능 시간(`attendanceStart` ~ `lateStart`)에 배너 표시 확인
- [ ] 지각 시간(`lateStart` ~ `absentStart`)에도 배너 표시 확인
- [ ] 결석 시간(`absentStart` 이후)에 배너 미표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 출석 배너 표시 로직을 개선하여 결석 시작 시간을 추가로 고려하도록 업데이트했습니다. 이제 현재 시간이 출석 시작 시간 이후이면서 결석 시작 시간 이전일 때만 배너가 표시됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->