### PR TITLE
[main] fix: 회식 상세 화면 시간이 KST로 변환되지 않던 문제 수정

### DIFF
--- a/apps/client/app/(auth)/after-party/[id]/_components/admin/after-party-info.tsx
+++ b/apps/client/app/(auth)/after-party/[id]/_components/admin/after-party-info.tsx
@@ -1,6 +1,7 @@
 import Link from 'next/link';
 import type { AfterPartyDetail } from '@dpm-core/api';
 import { Button, formatKoreanDate, formatKoreanDateWithTime } from '@dpm-core/shared';
+import { parseAfterPartyDateTime } from '../../../_utils/datetime';
 
 export interface InviteTag {
 	cohortId: number;
@@ -25,11 +26,15 @@ export const AfterPartyInfo = (props: AfterPartyDetail) => {
 				<div className="flex flex-col gap-3">
 					<div className="flex items-center gap-4 text-body2">
 						<p className="w-17.5 shrink-0 font-semibold text-label-assistive">회식 날짜</p>
-						<p className="font-medium text-label-subtle">{formatKoreanDate(scheduledAt)}</p>
+						<p className="font-medium text-label-subtle">
+							{formatKoreanDate(parseAfterPartyDateTime(scheduledAt))}
+						</p>
 					</div>
 					<div className="flex items-center gap-4 text-body2">
 						<p className="w-17.5 shrink-0 font-semibold text-label-assistive">조사 기한</p>
-						<p className="font-medium text-label-subtle">{formatKoreanDateWithTime(closedAt)}</p>
+						<p className="font-medium text-label-subtle">
+							{formatKoreanDateWithTime(parseAfterPartyDateTime(closedAt))}
+						</p>
 					</div>
 					<div className="flex items-center gap-4 text-body2">
 						<p className="w-17.5 shrink-0 font-semibold text-label-assistive">초대 범위</p>

--- a/apps/client/app/(auth)/after-party/[id]/_components/deeper/after-party-info.tsx
+++ b/apps/client/app/(auth)/after-party/[id]/_components/deeper/after-party-info.tsx
@@ -1,5 +1,6 @@
 import type { AfterPartyDetail } from '@dpm-core/api';
 import { formatKoreanDate, formatKoreanDateWithTime } from '@dpm-core/shared';
+import { parseAfterPartyDateTime } from '../../../_utils/datetime';
 
 interface AfterPartyInfoProps {
 	afterPartyDetail: AfterPartyDetail;
@@ -14,13 +15,13 @@ export const AfterPartyInfo = ({ afterPartyDetail }: AfterPartyInfoProps) => {
 				<div className="flex gap-4">
 					<div className="font-semibold text-body2 text-gray-400">회식 날짜</div>
 					<div className="font-medium text-body2 text-gray-600">
-						{formatKoreanDate(afterPartyDetail.scheduledAt)}
+						{formatKoreanDate(parseAfterPartyDateTime(afterPartyDetail.scheduledAt))}
 					</div>
 				</div>
 				<div className="flex gap-4">
 					<div className="font-semibold text-body2 text-gray-400">조사 기한</div>
 					<div className="font-medium text-body2 text-gray-600">
-						{formatKoreanDateWithTime(afterPartyDetail.closedAt)}
+						{formatKoreanDateWithTime(parseAfterPartyDateTime(afterPartyDetail.closedAt))}
 					</div>
 				</div>
 				<div className="flex gap-4">


### PR DESCRIPTION
## Summary
- 회식 상세 화면에서 `조사 기한`이 수정 화면과 9시간 차이(예: 상세 `오전 05시` vs 수정 `오후 02시`)로 표시되던 버그 수정
- 원인: API가 `Z` 없는 UTC 문자열(`"2026-05-08T05:00:00"`)로 내려주는 `scheduledAt`/`closedAt`을 `dayjs(date)`가 로컬(KST)로 잘못 파싱
- 수정: `parseAfterPartyDateTime`(`dayjs.utc(...)`)으로 UTC 파싱 후 포맷팅하도록 변경 — 수정 화면이 이미 사용 중인 방식과 통일

## Changes
- [admin/after-party-info.tsx](apps/client/app/(auth)/after-party/[id]/_components/admin/after-party-info.tsx)
- [deeper/after-party-info.tsx](apps/client/app/(auth)/after-party/[id]/_components/deeper/after-party-info.tsx)

## Test plan
- [ ] `/after-party/[id]` (디퍼): 조사 기한 / 회식 날짜가 수정 화면과 동일한 시각으로 표시되는지 확인
- [ ] `/after-party/[id]` (운영진): 조사 기한 / 회식 날짜가 수정 화면과 동일한 시각으로 표시되는지 확인
- [ ] 자정 근처 시간대(예: 새벽 1시 KST)에도 날짜가 정확히 표시되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * 파티 정보의 날짜 표시 로직을 개선했습니다. 예정된 날짜와 종료 날짜의 파싱 처리를 새로운 공유 유틸리티로 통합하여 여러 컴포넌트에서 일관되게 사용할 수 있도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->