### PR TITLE
fix: 편집 폼 로드 시 Z를 강제 추가해 올바른 KST 시간을 복원하도록 수정

### DIFF
--- a/apps/admin/app/(auth)/announcement/[id]/edit/page.tsx
+++ b/apps/admin/app/(auth)/announcement/[id]/edit/page.tsx
@@ -14,13 +14,34 @@ import { getAnnouncementDetailQuery } from '@/remotes/queries/announcement';
 
 import { NoticeForm } from '../../_components/notice-form';
 
-/** ISO date-time 문자열에서 HHMM 4자리 추출 */
+/** 서버가 Z 없이 UTC 문자열을 반환하므로 Z를 붙여 UTC로 강제 파싱 */
+function toUTCDate(isoString: string): Date {
+	// Z나 타임존 오프셋(+XX:XX, -XX:XX)이 없는 경우에만 Z 추가
+	const hasTimezone = /Z|[+-]\d{2}:\d{2}$/.test(isoString);
+
+	return new Date(hasTimezone ? isoString : `${isoString}Z`);
+}
+
+/** ISO date-time 문자열에서 HHMM 4자리 추출 (서버 UTC → KST 변환 후 표시) */
 function extractTimeHHMM(isoString?: string): string {
 	if (!isoString) return '';
-	const date = new Date(isoString);
-	const hours = String(date.getHours()).padStart(2, '0');
-	const minutes = String(date.getMinutes()).padStart(2, '0');
+
+	const date = toUTCDate(isoString);
+	// UTC 시간에 9시간 더해서 KST로 변환
+	const kstDate = new Date(date.getTime() + 9 * 60 * 60 * 1000);
+
+	const hours = String(kstDate.getUTCHours()).padStart(2, '0');
+	const minutes = String(kstDate.getUTCMinutes()).padStart(2, '0');
+
 	return `${hours}${minutes}`;
+}
+
+/** ISO date-time 문자열에서 Calendar용 로컬 Date 생성 (UTC 파싱 후 KST 날짜 기준) */
+function extractCalendarDate(isoString: string): Date {
+	const d = toUTCDate(isoString);
+	// UTC에 9시간 더해서 KST 날짜 추출
+	const kstDate = new Date(d.getTime() + 9 * 60 * 60 * 1000);
+	return new Date(kstDate.getUTCFullYear(), kstDate.getUTCMonth(), kstDate.getUTCDate());
 }
 
 /** 서버 응답을 폼 초기값으로 변환 */
@@ -42,7 +63,7 @@ function toFormDefaults(detail: AnnouncementDetail): Partial<NoticeSchema> {
 	};
 
 	if (detail.scheduledAt) {
-		defaults.scheduledDate = new Date(detail.scheduledAt);
+		defaults.scheduledDate = extractCalendarDate(detail.scheduledAt);
 		defaults.scheduledTime = extractTimeHHMM(detail.scheduledAt);
 	}
 
@@ -51,11 +72,11 @@ function toFormDefaults(detail: AnnouncementDetail): Partial<NoticeSchema> {
 		defaults.submissionLink = detail.assignment.submitLink ?? '';
 
 		if (detail.assignment.startAt) {
-			defaults.submissionStartDate = new Date(detail.assignment.startAt);
+			defaults.submissionStartDate = extractCalendarDate(detail.assignment.startAt);
 			defaults.submissionStartTime = extractTimeHHMM(detail.assignment.startAt);
 		}
 		if (detail.assignment.dueAt) {
-			defaults.submissionEndDate = new Date(detail.assignment.dueAt);
+			defaults.submissionEndDate = extractCalendarDate(detail.assignment.dueAt);
 			defaults.submissionEndTime = extractTimeHHMM(detail.assignment.dueAt);
 		}
 	}
@@ -81,12 +102,7 @@ const EditNoticeContent = ({ announcementId }: EditNoticeContentProps) => {
 	});
 
 	return (
-		<NoticeForm
-			mode="edit"
-			form={form}
-			onSubmit={handleSubmit}
-			isSubmitPending={isSubmitPending}
-		/>
+		<NoticeForm mode="edit" form={form} onSubmit={handleSubmit} isSubmitPending={isSubmitPending} />
 	);
 };
 

--- a/apps/admin/app/(auth)/announcement/create/_utils/build-announcement-payload.ts
+++ b/apps/admin/app/(auth)/announcement/create/_utils/build-announcement-payload.ts
@@ -2,13 +2,13 @@ import type { CreateAnnouncementRequest } from '@dpm-core/api';
 
 import type { NoticeSchema } from '../_schemas/notice-schema';
 
-/** Date + HHMM(4자리) → ISO date-time 문자열 */
+/** Date + HHMM(4자리) → ISO date-time 문자열 (입력한 시:분을 UTC 기준으로 직접 사용) */
 function toISOAt(date: Date, timeHHMM: string): string {
 	const hours = Number.parseInt(timeHHMM.slice(0, 2), 10);
 	const minutes = Number.parseInt(timeHHMM.slice(2, 4), 10);
-	const d = new Date(date);
-	d.setHours(hours, minutes, 0, 0);
-	return d.toISOString();
+	return new Date(
+		Date.UTC(date.getFullYear(), date.getMonth(), date.getDate(), hours, minutes, 0, 0),
+	).toISOString();
 }
 
 /** 폼 데이터를 공지 등록 API body로 변환 */


### PR DESCRIPTION
## 📌 개요

> 참고 링크

https://github.com/depromeet/dpm-core-client/pull/262

## 📋 변경사항

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

### 스크린샷

| 작업 전 | 작업 후 |
| ------- | ------- |

## 🙏 참고사항

> 리뷰어는 '참고사항'의 요소들을 고려해주세요.

### 리뷰 희망 기한



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 공지사항 편집 페이지에서 시간대 정보가 없는 날짜 문자열 처리 개선
  * 공지사항 등록 시 날짜 및 시간 필드의 타임존 변환 로직 정확화
  * 폼 초기값의 날짜 및 시간 데이터가 올바른 시간대로 표시되도록 수정

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/dpm-core-client/pull/263)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->