### PR TITLE
fix: 회식 '내 팀만 보기' 필터 팀 미배정 유저 대응

### DIFF
--- a/apps/client/app/(auth)/after-party/[id]/_components/deeper/invited-member-list.tsx
+++ b/apps/client/app/(auth)/after-party/[id]/_components/deeper/invited-member-list.tsx
@@ -33,7 +33,7 @@ export const InvitedMemberList = ({ afterPartyId, isClosed }: InvitedMemberListP
 	const members = invitedMembersData.data;
 
 	const applyTeamFilter = (list: AfterPartyInvitedMember[]) => {
-		if (myTeamOnly && user?.teamNumber) {
+		if (myTeamOnly && user) {
 			return list.filter((m) => m.teamNumber === user.teamNumber);
 		}
 		return list;
@@ -81,24 +81,22 @@ export const InvitedMemberList = ({ afterPartyId, isClosed }: InvitedMemberListP
 							</TabsTrigger>
 						</TabsList>
 					)}
-					{user?.teamNumber ? (
-						<div className="flex items-center gap-1.5">
-							<Checkbox
-								className="size-4 cursor-pointer rounded-sm border-line-normal text-gray-0 shadow-none data-[state=checked]:bg-primary-normal"
-								id="my-team-only"
-								checked={myTeamOnly}
-								onCheckedChange={(checked: boolean | 'indeterminate') =>
-									setMyTeamOnly(checked === true)
-								}
-							/>
-							<Label
-								htmlFor="my-team-only"
-								className="cursor-pointer font-medium text-body2 text-label-assistive"
-							>
-								내 팀만 보기
-							</Label>
-						</div>
-					) : null}
+					<div className="flex items-center gap-1.5">
+						<Checkbox
+							className="size-4 cursor-pointer rounded-sm border-line-normal text-gray-0 shadow-none data-[state=checked]:bg-primary-normal"
+							id="my-team-only"
+							checked={myTeamOnly}
+							onCheckedChange={(checked: boolean | 'indeterminate') =>
+								setMyTeamOnly(checked === true)
+							}
+						/>
+						<Label
+							htmlFor="my-team-only"
+							className="cursor-pointer font-medium text-body2 text-label-assistive"
+						>
+							내 팀만 보기
+						</Label>
+					</div>
 				</div>
 
 				{isClosed ? (

--- a/apps/client/app/(auth)/after-party/[id]/attendees/_components/after-party-attendees-filter.tsx
+++ b/apps/client/app/(auth)/after-party/[id]/attendees/_components/after-party-attendees-filter.tsx
@@ -53,7 +53,7 @@ export const AfterPartyAttendeesFilter = () => {
 					미참석
 				</ToggleGroupItem>
 			</ToggleGroup>
-			{user?.teamNumber && (
+			{user && (
 				<div className="flex items-center gap-1.5">
 					<Checkbox
 						id="isMyTeam"

--- a/apps/client/app/(auth)/after-party/[id]/participants/_components/after-party-participants-filter.tsx
+++ b/apps/client/app/(auth)/after-party/[id]/participants/_components/after-party-participants-filter.tsx
@@ -53,7 +53,7 @@ export const AfterPartyParticipantsFilter = () => {
 					제출
 				</ToggleGroupItem>
 			</ToggleGroup>
-			{user?.teamNumber && (
+			{user && (
 				<div className="flex items-center gap-1.5">
 					<Checkbox
 						id="isMyTeam"


### PR DESCRIPTION
## Summary
- 직전 PR (#264, #265) 후속. 팀 미배정 유저(`teamNumber === 0`)는 체크박스가 숨겨졌었는데, **팀 미배정끼리도 하나의 그룹으로 필터링되어야** 한다는 요구사항에 맞춰 동작 변경
- `0`도 유효한 그룹값으로 취급하도록 가드를 `user?.teamNumber` → `user`로 변경

## Changes
- [invited-member-list.tsx](apps/client/app/(auth)/after-party/[id]/_components/deeper/invited-member-list.tsx)
  - 필터 조건 `myTeamOnly && user?.teamNumber` → `myTeamOnly && user`
  - 체크박스 숨김 가드(`{user?.teamNumber ? ... : null}`) 제거
- [after-party-attendees-filter.tsx](apps/client/app/(auth)/after-party/[id]/attendees/_components/after-party-attendees-filter.tsx)
  - 체크박스 가시성 가드 `{user?.teamNumber && ...}` → `{user && ...}`
- [after-party-participants-filter.tsx](apps/client/app/(auth)/after-party/[id]/participants/_components/after-party-participants-filter.tsx) 동일

attendees-list / participants-list의 매칭 로직은 strict equality(`teamNumber === user?.teamNumber`)라 `0`도 자연스럽게 매칭됨 — 별도 수정 불필요.

## Test plan
- [ ] 팀 미배정 계정: 세 페이지 모두 체크박스 노출, 체크 시 팀 미배정 멤버만 표시
- [ ] 1팀 계정: 체크 시 1팀 멤버만 표시 (참석/불참, 참석자/미참석자, 미제출/제출 탭 모두)
- [ ] 체크 해제 시 전체 리스트 복귀

develop 향 동일 수정 PR은 별도로 올림.

🤖 Generated with [Claude Code](https://claude.com/claude-code)