### PR TITLE
feat: 네이티브 카카오 로그인 SDK 연동

### DIFF
--- a/apps/client/components/login-button.tsx
+++ b/apps/client/components/login-button.tsx
@@ -48,7 +48,10 @@ const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
 					return;
 				}
 
-				await auth.kakaoLogin({ accessToken: result.accessToken });
+				await auth.kakaoLogin({
+					accessToken: result.accessToken,
+					refreshToken: result.refreshToken,
+				});
 				router.replace('/');
 			} catch {
 				toast.error('카카오 로그인에 실패했습니다.');

--- a/apps/client/components/login-button.tsx
+++ b/apps/client/components/login-button.tsx
@@ -18,7 +18,7 @@ interface LoginButtonProps {
 }
 
 const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
-	({ variant, size, className }, ref) => {
+	({ href, variant, size, className }, ref) => {
 		const router = useRouter();
 		const { isApp } = useAppConfig();
 		const { isWebViewBridgeAvailable, isNativeMethodAvailable } = useBridgeStatus();
@@ -63,7 +63,7 @@ const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
 		return (
 			<Pressable ref={ref} variant={variant} size={size} className={className} asChild>
 				<a
-					href={webFallbackUrl}
+					href={href ?? webFallbackUrl}
 					onClick={handleClick}
 					className="flex items-center gap-2 font-medium text-sm"
 				>

--- a/apps/client/components/login-button.tsx
+++ b/apps/client/components/login-button.tsx
@@ -1,8 +1,12 @@
 'use client';
 
-import { type ComponentPropsWithoutRef, forwardRef } from 'react';
-import { BASE_URL } from '@dpm-core/api';
-import { type Button, KakaoLogo } from '@dpm-core/shared';
+import { useRouter } from 'next/navigation';
+import { type ComponentPropsWithoutRef, forwardRef, useState } from 'react';
+import { auth, BASE_URL } from '@dpm-core/api';
+import { type Button, KakaoLogo, toast } from '@dpm-core/shared';
+
+import { useAppConfig } from '@/providers/app-config-provider';
+import { useBridgeStatus, useBridgeStore } from '@/providers/bridge-provider';
 
 import { Pressable } from './motion';
 
@@ -15,11 +19,51 @@ interface LoginButtonProps {
 
 const LoginButton = forwardRef<HTMLButtonElement, LoginButtonProps>(
 	({ variant, size, className }, ref) => {
-		const loginUrl = new URL(BASE_URL ?? '');
-		loginUrl.pathname = '/login/kakao';
+		const router = useRouter();
+		const { isApp } = useAppConfig();
+		const { isWebViewBridgeAvailable, isNativeMethodAvailable } = useBridgeStatus();
+		const kakaoLogin = useBridgeStore(({ kakaoLogin }) => kakaoLogin);
+		const [isPending, setIsPending] = useState(false);
+
+		const canUseNativeKakao =
+			isApp && isWebViewBridgeAvailable && isNativeMethodAvailable('kakaoLogin');
+
+		const webFallbackUrl = (() => {
+			const url = new URL(BASE_URL ?? '');
+			url.pathname = '/login/kakao';
+			return url.toString();
+		})();
+
+		const handleClick = async (e: React.MouseEvent<HTMLAnchorElement>) => {
+			if (!canUseNativeKakao) return;
+
+			e.preventDefault();
+			if (isPending) return;
+
+			setIsPending(true);
+			try {
+				const result = await kakaoLogin();
+				if (!result.success) {
+					toast.error(result.error);
+					return;
+				}
+
+				await auth.kakaoLogin({ accessToken: result.accessToken });
+				router.replace('/');
+			} catch {
+				toast.error('카카오 로그인에 실패했습니다.');
+			} finally {
+				setIsPending(false);
+			}
+		};
+
 		return (
 			<Pressable ref={ref} variant={variant} size={size} className={className} asChild>
-				<a href={loginUrl.toString()} className="flex items-center gap-2 font-medium text-sm">
+				<a
+					href={webFallbackUrl}
+					onClick={handleClick}
+					className="flex items-center gap-2 font-medium text-sm"
+				>
 					<KakaoLogo />
 					<p className="flex-1 text-[#000000] opacity-85">카카오로 시작하기</p>
 				</a>

--- a/apps/native/app.config.js
+++ b/apps/native/app.config.js
@@ -1,3 +1,14 @@
+const kakaoNativeAppKey = process.env.KAKAO_NATIVE_APP_KEY;
+const isProductionBuild = process.env.EAS_BUILD_PROFILE === 'production';
+
+if (!kakaoNativeAppKey && isProductionBuild) {
+	throw new Error('KAKAO_NATIVE_APP_KEY is required for production builds');
+}
+
+if (!kakaoNativeAppKey) {
+	console.warn('⚠️ KAKAO_NATIVE_APP_KEY is not set. Kakao login will be disabled.');
+}
+
 /** @type {import('expo/config').ExpoConfig} */
 const config = {
 	name: 'Depromeet',
@@ -65,7 +76,7 @@ const config = {
 		[
 			'@react-native-kakao/core',
 			{
-				nativeAppKey: process.env.KAKAO_NATIVE_APP_KEY,
+				nativeAppKey: kakaoNativeAppKey,
 				android: { authCodeHandlerActivity: true },
 				ios: { handleKakaoOpenUrl: true },
 			},
@@ -81,7 +92,7 @@ const config = {
 		eas: {
 			projectId: '036040bf-3e75-4d0e-877c-cb579653f8e8',
 		},
-		kakaoNativeAppKey: process.env.KAKAO_NATIVE_APP_KEY,
+		kakaoNativeAppKey,
 	},
 };
 

--- a/apps/native/app.config.js
+++ b/apps/native/app.config.js
@@ -62,6 +62,14 @@ const config = {
 				color: '#ffffff',
 			},
 		],
+		[
+			'@react-native-kakao/core',
+			{
+				nativeAppKey: process.env.KAKAO_NATIVE_APP_KEY,
+				android: { authCodeHandlerActivity: true },
+				ios: { handleKakaoOpenUrl: true },
+			},
+		],
 	],
 	experiments: {
 		typedRoutes: true,
@@ -73,6 +81,7 @@ const config = {
 		eas: {
 			projectId: '036040bf-3e75-4d0e-877c-cb579653f8e8',
 		},
+		kakaoNativeAppKey: process.env.KAKAO_NATIVE_APP_KEY,
 	},
 };
 

--- a/apps/native/app/_layout.tsx
+++ b/apps/native/app/_layout.tsx
@@ -1,5 +1,13 @@
+import { initializeKakaoSDK } from '@react-native-kakao/core';
+import Constants from 'expo-constants';
 import * as Notifications from 'expo-notifications';
 import { SplashScreen, Stack } from 'expo-router';
+
+const kakaoNativeAppKey = Constants.expoConfig?.extra?.kakaoNativeAppKey as string | undefined;
+
+if (kakaoNativeAppKey) {
+	initializeKakaoSDK(kakaoNativeAppKey);
+}
 
 // 앱이 포그라운드일 때 수신된 알림 표시 방식 설정
 Notifications.setNotificationHandler({

--- a/apps/native/bridge/app-bridge.ts
+++ b/apps/native/bridge/app-bridge.ts
@@ -1,3 +1,4 @@
+import { login as kakaoLoginNative } from '@react-native-kakao/user';
 import { bridge } from '@webview-bridge/react-native';
 import * as WebBrowser from 'expo-web-browser';
 
@@ -16,6 +17,15 @@ export const appBridge = bridge({
 			return { success: true as const, token };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : '알 수 없는 오류가 발생했습니다.';
+			return { success: false as const, error: message };
+		}
+	},
+	async kakaoLogin() {
+		try {
+			const result = await kakaoLoginNative();
+			return { success: true as const, accessToken: result.accessToken };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : '카카오 로그인에 실패했습니다.';
 			return { success: false as const, error: message };
 		}
 	},

--- a/apps/native/bridge/app-bridge.ts
+++ b/apps/native/bridge/app-bridge.ts
@@ -23,7 +23,11 @@ export const appBridge = bridge({
 	async kakaoLogin() {
 		try {
 			const result = await kakaoLoginNative();
-			return { success: true as const, accessToken: result.accessToken };
+			return {
+				success: true as const,
+				accessToken: result.accessToken,
+				refreshToken: result.refreshToken,
+			};
 		} catch (error) {
 			const message = error instanceof Error ? error.message : '카카오 로그인에 실패했습니다.';
 			return { success: false as const, error: message };

--- a/apps/native/package.json
+++ b/apps/native/package.json
@@ -17,6 +17,8 @@
 	},
 	"dependencies": {
 		"@expo/vector-icons": "^15.0.3",
+		"@react-native-kakao/core": "^2.4.0",
+		"@react-native-kakao/user": "^2.4.0",
 		"@react-navigation/bottom-tabs": "^7.4.0",
 		"@react-navigation/elements": "^2.6.3",
 		"@react-navigation/native": "^7.1.8",

--- a/apps/native/scripts/get-kakao-debug-keyhash.sh
+++ b/apps/native/scripts/get-kakao-debug-keyhash.sh
@@ -1,0 +1,93 @@
+#!/usr/bin/env bash
+# 카카오 로그인용 Android Debug 키해시 추출 스크립트
+#
+# 사용:
+#   ./apps/native/scripts/get-kakao-debug-keyhash.sh
+#
+# 동작:
+#   1. ~/.android/debug.keystore 가 없으면 생성
+#   2. 키스토어의 SHA-1을 Base64로 변환 (카카오 키해시 포맷)
+#   3. 결과 출력 + 카카오 디벨로퍼스 등록 안내
+
+set -e
+
+KEYSTORE="$HOME/.android/debug.keystore"
+STOREPASS="android"
+KEYPASS="android"
+ALIAS="androiddebugkey"
+
+# keytool이 실제로 실행 가능한지 확인 (macOS의 /usr/bin/keytool 스텁은 Java 안내만 띄움)
+is_working_keytool() {
+	"$1" -help >/dev/null 2>&1
+}
+
+# Android Studio 번들 JDK 우선 → 시스템 keytool fallback
+find_keytool() {
+	local candidates=(
+		"/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/keytool"
+		"/Applications/Android Studio Preview.app/Contents/jbr/Contents/Home/bin/keytool"
+		"$HOME/Library/Android/sdk/jdk/Contents/Home/bin/keytool"
+	)
+
+	for c in "${candidates[@]}"; do
+		if [ -x "$c" ] && is_working_keytool "$c"; then
+			echo "$c"
+			return
+		fi
+	done
+
+	if command -v keytool >/dev/null 2>&1 && is_working_keytool "keytool"; then
+		echo "keytool"
+		return
+	fi
+
+	return 1
+}
+
+KEYTOOL="$(find_keytool || true)"
+if [ -z "$KEYTOOL" ]; then
+	echo "❌ keytool을 찾을 수 없습니다."
+	echo "   Android Studio를 설치하거나 JDK를 설치해주세요."
+	echo "   - Android Studio: https://developer.android.com/studio"
+	exit 1
+fi
+
+# debug.keystore 생성 (없을 때만)
+if [ ! -f "$KEYSTORE" ]; then
+	echo "▶ debug.keystore 생성 중..."
+	mkdir -p "$(dirname "$KEYSTORE")"
+	"$KEYTOOL" -genkey -v \
+		-keystore "$KEYSTORE" \
+		-storepass "$STOREPASS" \
+		-keypass "$KEYPASS" \
+		-alias "$ALIAS" \
+		-keyalg RSA -keysize 2048 -validity 10000 \
+		-dname "CN=Android Debug,O=Android,C=US" >/dev/null 2>&1
+	echo "✅ 생성 완료: $KEYSTORE"
+fi
+
+# SHA-1 → Base64 변환
+KEYHASH=$(
+	"$KEYTOOL" -exportcert \
+		-alias "$ALIAS" \
+		-keystore "$KEYSTORE" \
+		-storepass "$STOREPASS" \
+		-keypass "$KEYPASS" 2>/dev/null \
+		| openssl sha1 -binary \
+		| openssl base64
+)
+
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo "  카카오 디벨로퍼스 Android 키해시"
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "  $KEYHASH"
+echo ""
+echo "━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━"
+echo ""
+echo "등록 위치:"
+echo "  https://developers.kakao.com"
+echo "  → 내 애플리케이션 → 앱 선택 → 플랫폼 → Android"
+echo "  → 키 해시 항목에 위 값 추가 (= 포함)"
+echo ""

--- a/docs/KAKAO_KEYHASH_SETUP.md
+++ b/docs/KAKAO_KEYHASH_SETUP.md
@@ -1,0 +1,150 @@
+# 카카오 로그인 Android 키해시 등록 가이드
+
+> Android 환경에서 카카오 네이티브 SDK 로그인을 사용하려면, 빌드 키스토어의 SHA-1 지문을 Base64로 변환한 **키해시**를 카카오 디벨로퍼스 콘솔에 등록해야 합니다.
+
+## 1. 왜 키해시가 필요한가
+
+Android는 누구나 우리 앱 패키지명(`com.depromeet.core.app`)을 흉내낼 수 있습니다. 카카오는 패키지명만으로는 진위 확인이 안 되기 때문에, **앱 서명 키의 지문(SHA-1)**을 추가 검증합니다.
+
+```
+[진짜 우리 앱]                          [가짜 앱]
+서명: 우리 키스토어                     서명: 임의의 키스토어
+지문: 등록된 키해시                     지문: 등록 안 된 키해시
+       ↓                                       ↓
+카카오 서버: 통과                       카카오 서버: 거부 (KOE006)
+```
+
+서명 키스토어는 위조 불가능한 비밀이라 "진짜 우리 앱만" 통과시킬 수 있습니다.
+
+## 2. 어떤 키해시를 등록해야 하나
+
+빌드 종류마다 다른 키스토어로 서명되기 때문에 각각 등록해야 합니다.
+
+| 빌드 | 서명 키스토어 | 등록 주체 | 빈도 |
+|---|---|---|---|
+| **EAS 클라우드 빌드** (production / preview / development) | EAS Upload Key | 팀 공통 (한 번) | 1회 |
+| **Play Store 정식 배포** | Google App Signing Key | 팀 공통 (한 번) | 1회 |
+| **로컬 컴파일** (`expo run:android`, Android Studio) | 각자의 `~/.android/debug.keystore` | **개발자 본인** | 머신마다 |
+
+→ **EAS Build만 쓰면** 팀 공통 키해시 2개로 충분.
+→ **로컬에서 직접 컴파일하면** 각자 자기 머신 키해시를 추가 등록 필요.
+
+## 3. 로컬 debug 키해시 등록 (개발자 본인)
+
+### 3-1. 스크립트 실행
+
+```bash
+./apps/native/scripts/get-kakao-debug-keyhash.sh
+```
+
+이 스크립트가 자동으로:
+1. `~/.android/debug.keystore`가 없으면 생성
+2. SHA-1을 Base64로 변환
+3. 카카오에 등록할 키해시 출력
+
+출력 예시:
+```
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+  카카오 디벨로퍼스 Android 키해시
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+
+  ZGKEJLTDR9hVuTnfpA6yqaY7hjo=
+```
+
+### 3-2. 카카오 디벨로퍼스에 등록
+
+1. <https://developers.kakao.com/> 로그인
+2. **내 애플리케이션** → 우리 앱 선택
+3. 좌측 메뉴 **앱 설정 → 플랫폼**
+4. **Android 플랫폼**의 **키 해시** 항목 → **추가**
+5. 위에서 받은 값(`=` 포함, 28자) 붙여넣기
+6. **저장**
+
+> ⚠️ `=` 빠뜨리지 마세요. 카카오는 패딩 포함 전체 문자열로 매칭합니다.
+
+### 3-3. 사전 요구사항
+
+스크립트가 동작하려면 다음 중 하나가 필요합니다:
+
+- **Android Studio 설치** (권장): <https://developer.android.com/studio>
+  - 스크립트가 Android Studio 번들 JDK를 자동으로 찾아 사용
+- **시스템 JDK 설치**: `brew install openjdk` 등
+
+macOS의 `/usr/bin/keytool` 은 "Java 설치하세요" 안내만 띄우는 스텁이라 실제 동작하지 않습니다. 스크립트가 알아서 우회합니다.
+
+### 3-4. 수동으로 추출 (스크립트 안 쓰고 싶다면)
+
+```bash
+# debug.keystore 생성 (없으면)
+KEYTOOL="/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/keytool"
+"$KEYTOOL" -genkey -v \
+  -keystore ~/.android/debug.keystore \
+  -storepass android -keypass android \
+  -alias androiddebugkey \
+  -keyalg RSA -keysize 2048 -validity 10000 \
+  -dname "CN=Android Debug,O=Android,C=US"
+
+# 키해시 추출
+"$KEYTOOL" -exportcert \
+  -alias androiddebugkey \
+  -keystore ~/.android/debug.keystore \
+  -storepass android -keypass android \
+  | openssl sha1 -binary | openssl base64
+```
+
+## 4. 팀 공통 키해시 등록 (이미 등록됨)
+
+> 이 섹션은 참고용. 신규 환경 구축 시에만 다시 할 일.
+
+### 4-1. EAS Upload Key
+
+```
+Expo Dashboard → Credentials → Android → Keystore → SHA-1 인증서 지문
+```
+
+→ SHA-1 (`14:ED:8C:48:...` 형식) 을 Base64로 변환:
+
+```bash
+echo "14:ED:8C:48:..." \
+  | awk -F: '{for(i=1;i<=NF;i++)printf "%s",$i}' \
+  | xxd -r -p | openssl base64
+```
+
+### 4-2. Play Store App Signing Key
+
+```
+Google Play Console → 앱 선택 → 출시 → 설정 → 앱 서명 → 앱 서명 키 인증서의 SHA-1
+```
+
+→ 위와 동일하게 Base64 변환 후 등록.
+
+## 5. 검증
+
+### 키해시 등록이 잘 된 경우
+- 로그인 버튼 탭 → KakaoTalk 앱 실행 → 인증 → 성공
+
+### 키해시 미등록 / 불일치
+- `KakaoSdkError: KOE006 (앱 키가 등록되지 않았거나 키 해시 불일치)`
+- 또는 `not registered key hash` 메시지
+
+이 에러가 나면:
+1. 카카오 콘솔에 본인 키해시 등록 여부 재확인
+2. `=` 패딩 포함 28자 전체를 정확히 입력했는지 확인
+3. 카카오 콘솔에서 **저장** 버튼을 눌렀는지 확인 (입력만 하고 저장 안 하면 반영 안 됨)
+
+## 6. 자주 묻는 질문
+
+**Q. iOS는 키해시 안 등록해도 되나?**
+A. iOS는 Apple이 앱 배포를 통제하기 때문에 Bundle ID만으로 검증 충분. 키해시 개념 자체가 없음.
+
+**Q. 팀원이 늘 때마다 키해시 등록해야 하나?**
+A. 로컬 컴파일 방식이면 그렇습니다. 그래서 가능하면 **EAS Dev Build를 공유해서 쓰는 방식**이 운영 부담이 적습니다. 한 명이 빌드해서 .apk 공유 → 팀원들은 그걸 설치 + 메트로 서버만 띄워 개발.
+
+**Q. 키해시는 비밀 정보인가?**
+A. 아닙니다. **공개 정보입니다.** SHA-1 fingerprint는 인증서의 공개 지문일 뿐이라 노출돼도 보안 위험 없음. 비밀은 키스토어 파일 자체 (`.jks`).
+
+**Q. `~/.android/debug.keystore` 가 사라지면?**
+A. 새로 생성하면 됩니다. **새 키스토어는 다른 SHA-1을 가지므로 카카오에 다시 등록 필요.** 일관성 유지를 위해 안 지우는 게 좋습니다.
+
+**Q. CI에서 Android 빌드 시 키해시는?**
+A. CI가 EAS Build를 트리거하는 구조라면 EAS Upload Key 그대로 쓰니까 추가 등록 불필요. CI 머신이 직접 컴파일하는 구조면 그 머신의 debug 키해시 등록 필요.

--- a/packages/api/src/auth/remote.ts
+++ b/packages/api/src/auth/remote.ts
@@ -16,6 +16,10 @@ export const auth = {
 		const res = await http.post('login/email', { json: params });
 		return res;
 	},
+	kakaoLogin: async (params: { accessToken: string }) => {
+		const res = await http.post('login/auth/kakao', { json: params });
+		return res;
+	},
 	logout: async () => {
 		const res = await http.post('logout');
 		return res;

--- a/packages/api/src/auth/remote.ts
+++ b/packages/api/src/auth/remote.ts
@@ -16,8 +16,8 @@ export const auth = {
 		const res = await http.post('login/email', { json: params });
 		return res;
 	},
-	kakaoLogin: async (params: { accessToken: string }) => {
-		const res = await http.post('login/auth/kakao', { json: params });
+	kakaoLogin: async (params: { accessToken: string; refreshToken: string }) => {
+		const res = await http.post('login/auth/kakao/tokens', { json: params });
 		return res;
 	},
 	logout: async () => {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,12 @@ importers:
       '@expo/vector-icons':
         specifier: ^15.0.3
         version: 15.1.1(expo-font@14.0.11(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native-kakao/core':
+        specifier: ^2.4.0
+        version: 2.4.5(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      '@react-native-kakao/user':
+        specifier: ^2.4.0
+        version: 2.4.5(@react-native-kakao/core@2.4.5(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: ^7.4.0
         version: 7.15.5(@react-navigation/native@7.1.33(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1575,6 +1581,9 @@ packages:
   '@manypkg/get-packages@1.1.3':
     resolution: {integrity: sha512-fo+QhuU3qE/2TQMQmbVMqaQ6EWbMhi4ABWP+O4AM1NqPBuy0OrApV5LO6BrrgnhtAHS2NH6RrVk9OL181tTi8A==}
 
+  '@mj-studio/js-util@1.1.3':
+    resolution: {integrity: sha512-XZe1V3J1CJ9DbPY0GlPTOES7UdnWcoUe3kIjmUWMvwmunOb/kYuDWiswu5eogHhcPSlM3LpYQYU2HhMzf3N6tw==}
+
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
 
@@ -2266,6 +2275,23 @@ packages:
 
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
+
+  '@react-native-kakao/core@2.4.5':
+    resolution: {integrity: sha512-5X60QvsQxgPZOKFe6YB6SYMZZ7ysmMHNwqW4s30JXqO2tOBT4eB/PSltStTRdUoUr8kCLRiwW1kfpe63M1HsdQ==}
+    peerDependencies:
+      expo: '>=47.0.0'
+      react: '*'
+      react-native: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+
+  '@react-native-kakao/user@2.4.5':
+    resolution: {integrity: sha512-Mj+ppwg/ARBwgcyZz2H2u6fHfxr1H40Q/YSLAOKapn7C0GTXYynFOLH35psJwggTq4qbfIOMbcszOZSLcqwY8A==}
+    peerDependencies:
+      '@react-native-kakao/core': 2.4.5
+      react: '*'
+      react-native: '*'
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -3379,6 +3405,9 @@ packages:
     resolution: {integrity: sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==}
     engines: {node: '>= 8'}
 
+  crypto-js@4.2.0:
+    resolution: {integrity: sha512-KALDyEYgpY+Rlob/iriUtjV6d5Eq+Y191A5g4UqLAi8CyGP9N1+FdVbkc1SxKc2r4YAYqG8JzO2KGL+AizD70Q==}
+
   css-in-js-utils@3.1.0:
     resolution: {integrity: sha512-fJAcud6B3rRu+KHYk+Bwf+WFL2MDCJJ1XG9x137tJQ0xYxor7XziQtuGFbWNdqrvF4Tk26O3H73nfVqXt/fW1A==}
 
@@ -3434,6 +3463,10 @@ packages:
   decode-uri-component@0.2.2:
     resolution: {integrity: sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==}
     engines: {node: '>=0.10'}
+
+  decode-uri-component@0.4.1:
+    resolution: {integrity: sha512-+8VxcR21HhTy8nOt6jf20w0c9CADrw1O8d+VZ/YzzCt4bJ3uBjw+D1q2osAB8RnpwwaeYBxy0HyKQxD5JBMuuQ==}
+    engines: {node: '>=14.16'}
 
   deep-extend@0.6.0:
     resolution: {integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==}
@@ -3981,6 +4014,10 @@ packages:
   filter-obj@1.1.0:
     resolution: {integrity: sha512-8rXg1ZnX7xzy2NGDVkBVaAy+lSlPNwad13BtgSlLuxfIslyt5Vg64U7tFcCt4WS1R0hvtnQybT/IyCkGZ3DpXQ==}
     engines: {node: '>=0.10.0'}
+
+  filter-obj@5.1.0:
+    resolution: {integrity: sha512-qWeTREPoT7I0bifpPUXtxkZJ1XJzxWtfoWWkdVGqa+eCr3SHW/Ocp89o8vLvbUuQnadybJpjOKu4V+RwO6sGng==}
+    engines: {node: '>=14.16'}
 
   finalhandler@1.1.2:
     resolution: {integrity: sha512-aAWcW57uxVNrQZqFXjITpW3sIUQmHGG3qSb9mUah9MgMC4NeWhNOlNjXEYq3HjRAvL6arUviZGGJsBg6z0zsWA==}
@@ -5317,6 +5354,10 @@ packages:
     resolution: {integrity: sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg==}
     engines: {node: '>=6'}
 
+  query-string@9.3.1:
+    resolution: {integrity: sha512-5fBfMOcDi5SA9qj5jZhWAcTtDfKF5WFdd2uD9nVNlbxVv1baq65aALy6qofpNEGELHvisjjasxQp7BlM9gvMzw==}
+    engines: {node: '>=18'}
+
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
@@ -5566,6 +5607,9 @@ packages:
     resolution: {integrity: sha512-6IzJLuGi4+R14vwagDHX+JrXmPVtPpn4mffDJ1UdR7/Edm87fl6yi8mMBIVvFtJaNTUvjughmW4hwLhRG7gC1Q==}
     engines: {node: '>=4'}
 
+  return-fetch@0.4.8:
+    resolution: {integrity: sha512-v4QDtYcpZURU2x9fr+OqurHzuUBhudR+nrFxo8EwOY3nF35kMbE+t8FYtlmfJGfnrBun7dMJ5++VFjXjfwsWGQ==}
+
   reusify@1.1.0:
     resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
     engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
@@ -5748,6 +5792,10 @@ packages:
   split-on-first@1.1.0:
     resolution: {integrity: sha512-43ZssAJaMusuKWL8sKUBQXHWOpq8d6CfN/u1p4gUzfJkM05C8rxTmYrkIPTXapZpORA6LkkzcUulJ8FqA7Uudw==}
     engines: {node: '>=6'}
+
+  split-on-first@3.0.0:
+    resolution: {integrity: sha512-qxQJTx2ryR0Dw0ITYyekNQWpz6f8dGd7vffGNflQQ3Iqj9NJ6qiZ7ELpZsJ/QBhIVAiDfXdag3+Gp8RvWa62AA==}
+    engines: {node: '>=12'}
 
   sprintf-js@1.0.3:
     resolution: {integrity: sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==}
@@ -7696,6 +7744,8 @@ snapshots:
       globby: 11.1.0
       read-yaml-file: 1.1.0
 
+  '@mj-studio/js-util@1.1.3': {}
+
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
       '@emnapi/core': 1.8.1
@@ -8342,6 +8392,23 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.1.17)
 
   '@radix-ui/rect@1.1.1': {}
+
+  '@react-native-kakao/core@2.4.5(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      crypto-js: 4.2.0
+      query-string: 9.3.1
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
+      return-fetch: 0.4.8
+    optionalDependencies:
+      expo: 54.0.33(@babel/core@7.29.0)(@expo/metro-runtime@6.1.2)(expo-router@6.0.23)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
+  '@react-native-kakao/user@2.4.5(@react-native-kakao/core@2.4.5(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      '@mj-studio/js-util': 1.1.3
+      '@react-native-kakao/core': 2.4.5(expo@54.0.33)(react-native@0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.29.0)(@types/react@19.1.17)(react@19.1.0)
 
   '@react-native/assets-registry@0.81.5': {}
 
@@ -9643,6 +9710,8 @@ snapshots:
       shebang-command: 2.0.0
       which: 2.0.2
 
+  crypto-js@4.2.0: {}
+
   css-in-js-utils@3.1.0:
     dependencies:
       hyphenate-style-name: 1.1.0
@@ -9686,6 +9755,8 @@ snapshots:
       ms: 2.1.3
 
   decode-uri-component@0.2.2: {}
+
+  decode-uri-component@0.4.1: {}
 
   deep-extend@0.6.0: {}
 
@@ -10389,6 +10460,8 @@ snapshots:
       to-regex-range: 5.0.1
 
   filter-obj@1.1.0: {}
+
+  filter-obj@5.1.0: {}
 
   finalhandler@1.1.2:
     dependencies:
@@ -11963,6 +12036,12 @@ snapshots:
       split-on-first: 1.1.0
       strict-uri-encode: 2.0.0
 
+  query-string@9.3.1:
+    dependencies:
+      decode-uri-component: 0.4.1
+      filter-obj: 5.1.0
+      split-on-first: 3.0.0
+
   queue-microtask@1.2.3: {}
 
   queue@6.0.2:
@@ -12279,6 +12358,8 @@ snapshots:
       onetime: 2.0.1
       signal-exit: 3.0.7
 
+  return-fetch@0.4.8: {}
+
   reusify@1.1.0: {}
 
   rimraf@3.0.2:
@@ -12497,6 +12578,8 @@ snapshots:
       signal-exit: 4.1.0
 
   split-on-first@1.1.0: {}
+
+  split-on-first@3.0.0: {}
 
   sprintf-js@1.0.3: {}
 


### PR DESCRIPTION
## 📌 개요

WebView 환경에서 카카오 웹 OAuth 페이지로 빠지지 않고, KakaoTalk 앱을 직접 띄워 로그인하도록 네이티브 SDK 흐름을 추가했습니다.

> 참고 링크
> - [@react-native-kakao](https://github.com/react-native-kakao/react-native-kakao)
> - [Kakao Developers - Android SDK 시작하기](https://developers.kakao.com/docs/latest/ko/kakaologin/android)
> - main PR: #268

## 📋 변경사항

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

### 1. RN(Expo) 측 SDK 도입
- ``@react-native-kakao/core``, ``@react-native-kakao/user`` 패키지 추가
- ``app.config.js`` 에 Kakao Config Plugin 등록 → ``expo prebuild`` 시 iOS URL Scheme / Android intent-filter 자동 생성
- ``app.config.js`` 모듈 상단에 ``KAKAO_NATIVE_APP_KEY`` 누락 가드 (production 빌드 throw, 그 외 warn)
- ``_layout.tsx`` 진입 시점에 ``initializeKakaoSDK()`` 호출

### 2. Bridge 메서드 추가
- ``apps/native/bridge/app-bridge.ts`` 에 ``kakaoLogin()`` 추가
- 카카오 SDK에서 받은 ``accessToken`` / ``refreshToken`` 둘 다 반환
- 성공 시 ``{ success: true, accessToken, refreshToken }``, 실패 시 ``{ success: false, error }``

### 3. WebView 측 분기 처리
- ``apps/client/components/login-button.tsx`` 에서 ``isApp + bridge 가용성 + kakaoLogin 메서드 존재`` 3중 체크
- 모두 true → 네이티브 SDK 경로
- 하나라도 false → 기존 ``/login/kakao`` 웹 OAuth fallback (구버전 앱/웹 호환)
- ``href`` prop을 받으면 fallback URL보다 우선 사용

### 4. 백엔드 토큰 교환 API 헬퍼
- ``packages/api/src/auth/remote.ts`` 에 ``auth.kakaoLogin({ accessToken, refreshToken })`` 추가
- 백엔드 신규 엔드포인트 ``POST /login/auth/kakao/tokens`` 호출
- body에 카카오 access / refresh 토큰 둘 다 전달

### 5. 개발 환경 셋업 자동화
- ``apps/native/scripts/get-kakao-debug-keyhash.sh`` 스크립트 추가
- 개발자 머신의 ``~/.android/debug.keystore`` 자동 생성 + SHA-1 → Base64 변환
- macOS의 ``/usr/bin/keytool`` 스텁 우회 (Android Studio 번들 JDK 자동 탐색)
- ``docs/KAKAO_KEYHASH_SETUP.md`` 가이드 문서 추가

### 스크린샷

| 작업 전 | 작업 후 |
| ------- | ------- |
| WebView 안에 카카오 웹 로그인 페이지가 뜸 | KakaoTalk 앱이 떠서 인증 |

## 🙏 참고사항

> 리뷰어는 '참고사항'의 요소들을 고려해주세요.

### ⚠️ 머지 전 선행 작업

1. **백엔드 신규 엔드포인트 추가 필요**
   - ``POST /login/auth/kakao/tokens`` — 요청: ``{ accessToken: string, refreshToken: string }`` / 응답: Set-Cookie로 자체 세션 발급

2. **카카오 디벨로퍼스 콘솔 설정**
   - Android 키 해시 등록 (EAS Upload + Play App Signing + 개발자별 debug)
   - iOS Bundle ID 등록
   - 카카오 로그인 활성화 ON

3. **환경변수**
   - ``apps/native/.env`` 에 ``KAKAO_NATIVE_APP_KEY=...`` 추가
   - EAS Secret 등록

4. **네이티브 재빌드**
   - ``expo prebuild --clean`` + 새 .aab 빌드 필요

### 호환성

- 현재 배포된 앱(구버전): bridge에 ``kakaoLogin`` 메서드가 없으므로 자동으로 웹 OAuth fallback → 영향 없음
- 웹 브라우저: ``isApp=false`` 이므로 영원히 웹 OAuth → 영향 없음
- 새 .aab 배포 후: 네이티브 SDK 경로로 동작

### 리뷰 희망 기한

🤖 Generated with [Claude Code](https://claude.com/claude-code)