### PR TITLE
fix: eas webview url

### DIFF
--- a/apps/native/.gitignore
+++ b/apps/native/.gitignore
@@ -47,3 +47,7 @@ GoogleService-Info.plist
 
 expo-env.d.ts
 # @end expo-cli
+# EAS credentials
+credentials.json
+upload_key.pem
+credentials/

--- a/apps/native/app/index.tsx
+++ b/apps/native/app/index.tsx
@@ -15,10 +15,7 @@ export const { WebView } = createWebView({
 	debug: __DEV__,
 });
 
-const WEBVIEW_URL =
-	__DEV__ || process.env.APP_ENV === 'staging'
-		? 'https://core.depromeet.shop'
-		: 'https://core.depromeet.com';
+const WEBVIEW_URL = process.env.EXPO_PUBLIC_WEBVIEW_URL ?? 'https://core.depromeet.shop';
 
 function WebViewContainer() {
 	const webViewRef = useRef<NativeWebView>(null);

--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -9,7 +9,10 @@
 			"distribution": "internal"
 		},
 		"preview": {
-			"distribution": "internal"
+			"distribution": "internal",
+			"android": {
+				"buildType": "app-bundle"
+			}
 		},
 		"staging": {
 			"distribution": "store",

--- a/apps/native/eas.json
+++ b/apps/native/eas.json
@@ -6,12 +6,18 @@
 	"build": {
 		"development": {
 			"developmentClient": true,
-			"distribution": "internal"
+			"distribution": "internal",
+			"env": {
+				"EXPO_PUBLIC_WEBVIEW_URL": "https://core.depromeet.shop"
+			}
 		},
 		"preview": {
 			"distribution": "internal",
 			"android": {
 				"buildType": "app-bundle"
+			},
+			"env": {
+				"EXPO_PUBLIC_WEBVIEW_URL": "https://core.depromeet.shop"
 			}
 		},
 		"staging": {
@@ -21,7 +27,10 @@
 			}
 		},
 		"production": {
-			"autoIncrement": true
+			"autoIncrement": true,
+			"env": {
+				"EXPO_PUBLIC_WEBVIEW_URL": "https://core.depromeet.com"
+			}
 		}
 	},
 	"submit": {


### PR DESCRIPTION
## 📌 개요

> 참고 링크

## 📋 변경사항

> 리뷰어는 '변경사항'의 요소들을 검토해주세요.

### 스크린샷

| 작업 전 | 작업 후 |
| ------- | ------- |

## 🙏 참고사항

> 리뷰어는 '참고사항'의 요소들을 고려해주세요.

### 리뷰 희망 기한



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **설정 변경**
  * 웹뷰 URL 설정이 환경변수 기반으로 변경되었습니다.
  * 개발/프리뷰 빌드의 웹뷰 URL이 `https://core.depromeet.shop`으로, 프로덕션 빌드의 웹뷰 URL이 `https://core.depromeet.com`으로 설정되었습니다.
  * 빌드 구성이 개선되었습니다.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/depromeet/dpm-core-client/pull/270?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->