### PR TITLE
[develop] feat: Apple 초기 가입자 이름/직군 설정 바텀시트

### DIFF
--- a/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
+++ b/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import type { Part } from '@dpm-core/api';
+import {
+	Button,
+	Drawer,
+	DrawerContent,
+	DrawerFooter,
+	DrawerHeader,
+	DrawerTitle,
+	Input,
+	toast,
+	useAppShell,
+} from '@dpm-core/shared';
+
+import { updateAppleProfileMutationOptions } from '@/remotes/mutations/member';
+import { getMyMemberInfoQuery, getNameHashTypeValidationQuery } from '@/remotes/queries/member';
+
+import { useAppleProfileSetup } from '../_hooks/use-apple-profile-setup';
+import { PartSelector } from './part-selector';
+
+const MAX_NAME_LENGTH = 20;
+
+/**
+ * Apple 초기 가입자 프로필(이름/직군) 설정 바텀시트
+ *
+ * Apple 로그인 가입자의 name이 자동 생성값(이메일 local-part 또는 해시)인 경우,
+ * 홈(`/`) 진입 시 자동으로 노출되어 이름과 직군을 입력받는다.
+ * 운영진/멤버가 식별할 수 있도록 필수 설정이므로 외부 클릭/스와이프로 닫히지 않는다.
+ */
+export const AppleProfileSetupSheet = () => {
+	const { isSetupRequired, memberName } = useAppleProfileSetup();
+	const { ref } = useAppShell();
+	const queryClient = useQueryClient();
+
+	const [isOpen, setIsOpen] = useState(false);
+	const [name, setName] = useState('');
+	const [part, setPart] = useState<Part | null>(null);
+
+	// 설정이 필요해지면 자동으로 바텀시트를 연다.
+	useEffect(() => {
+		if (isSetupRequired) {
+			setIsOpen(true);
+		}
+	}, [isSetupRequired]);
+
+	const { mutate: updateProfile, isPending } = useMutation(updateAppleProfileMutationOptions());
+
+	const trimmedName = name.trim();
+	const isValid = trimmedName.length > 0 && part !== null;
+
+	const handleCancel = () => {
+		setIsOpen(false);
+	};
+
+	const handleSubmit = () => {
+		if (!isValid || part === null) return;
+
+		updateProfile(
+			{ name: trimmedName, part },
+			{
+				onSuccess: () => {
+					// 이름/해시 검증 캐시를 무효화해 시트 재노출을 방지한다.
+					queryClient.invalidateQueries({ queryKey: getMyMemberInfoQuery.queryKey });
+					queryClient.invalidateQueries({
+						queryKey: getNameHashTypeValidationQuery(memberName).queryKey,
+					});
+					setIsOpen(false);
+					toast.success('프로필이 설정되었어요.');
+				},
+				onError: () => {
+					toast.error('프로필 설정에 실패했어요. 다시 시도해주세요.');
+				},
+			},
+		);
+	};
+
+	return (
+		<Drawer open={isOpen} onOpenChange={setIsOpen} dismissible={false} container={ref.current}>
+			<DrawerContent
+				className="mx-auto pb-safe-area"
+				style={{ maxWidth: ref.current?.clientWidth ?? 'auto' }}
+			>
+				<DrawerHeader showCloseButton={false}>
+					<DrawerTitle className="font-semibold text-label-normal text-title2">
+						활동에 필요한 정보를 입력해주세요.
+					</DrawerTitle>
+				</DrawerHeader>
+
+				<div className="flex flex-col gap-6 px-6 py-4">
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-col gap-1">
+							<span className="font-semibold text-body1 text-label-normal">이름</span>
+							<span className="text-body2 text-label-assistive">본명을 입력해주세요.</span>
+						</div>
+						<Input
+							variant="line"
+							value={name}
+							onChange={(event) => setName(event.target.value)}
+							placeholder="이름을 입력해주세요"
+							maxLength={MAX_NAME_LENGTH}
+						/>
+					</div>
+
+					<div className="flex flex-col gap-2">
+						<div className="flex flex-col gap-1">
+							<span className="font-semibold text-body1 text-label-normal">파트</span>
+							<span className="text-body2 text-label-assistive">
+								디프만에서 활동 중인 파트를 선택해주세요.
+							</span>
+						</div>
+						<PartSelector value={part} onChange={setPart} name="apple-profile-part" />
+					</div>
+				</div>
+
+				<DrawerFooter>
+					<Button
+						variant="secondary"
+						size="full"
+						className="h-14 rounded-lg"
+						onClick={handleSubmit}
+						disabled={!isValid || isPending}
+					>
+						{isPending ? '저장 중...' : '저장'}
+					</Button>
+					<Button
+						variant="assistive"
+						size="full"
+						className="h-14 rounded-lg"
+						onClick={handleCancel}
+						disabled={isPending}
+					>
+						취소
+					</Button>
+				</DrawerFooter>
+			</DrawerContent>
+		</Drawer>
+	);
+};

--- a/apps/client/app/(home)/_components/part-selector.tsx
+++ b/apps/client/app/(home)/_components/part-selector.tsx
@@ -1,0 +1,51 @@
+'use client';
+
+import type { Part } from '@dpm-core/api';
+import { cn } from '@dpm-core/shared';
+
+/** 디자인 표기에 맞춘 직군 옵션 (순서: Android · IOS · Web · Server · Design) */
+const PART_OPTIONS: { value: Part; label: string }[] = [
+	{ value: 'ANDROID', label: 'Android' },
+	{ value: 'IOS', label: 'IOS' },
+	{ value: 'WEB', label: 'Web' },
+	{ value: 'SERVER', label: 'Server' },
+	{ value: 'DESIGN', label: 'Design' },
+];
+
+interface PartSelectorProps {
+	value: Part | null;
+	onChange: (part: Part) => void;
+	name: string;
+}
+
+export const PartSelector = ({ value, onChange, name }: PartSelectorProps) => {
+	return (
+		<div className="flex flex-col" role="radiogroup" aria-label="파트 선택">
+			{PART_OPTIONS.map(({ value: partValue, label }) => {
+				const isSelected = value === partValue;
+
+				return (
+					<label key={partValue} className="flex cursor-pointer items-center gap-3 py-2.5">
+						<input
+							type="radio"
+							name={name}
+							value={partValue}
+							checked={isSelected}
+							onChange={() => onChange(partValue)}
+							className="sr-only"
+						/>
+						<span
+							className={cn(
+								'flex size-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+								isSelected ? 'border-primary-normal' : 'border-line-normal',
+							)}
+						>
+							{isSelected && <span className="size-2.5 rounded-full bg-primary-normal" />}
+						</span>
+						<span className="font-medium text-body1 text-label-normal">{label}</span>
+					</label>
+				);
+			})}
+		</div>
+	);
+};

--- a/apps/client/app/(home)/_hooks/use-apple-profile-setup.ts
+++ b/apps/client/app/(home)/_hooks/use-apple-profile-setup.ts
@@ -1,0 +1,39 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getMyMemberInfoQuery, getNameHashTypeValidationQuery } from '@/remotes/queries/member';
+
+/**
+ * Apple 초기 가입자 프로필 설정 필요 여부 판단 훅
+ *
+ * Apple 로그인 가입자는 이름을 별도로 입력하지 않으면 name이 자동 생성된다.
+ *  1. 이메일 가리기(Private Relay): name이 식별 불가능한 해시(id) 형식 → `isHashType`
+ *  2. 실제 이메일 공유: name이 이메일의 local-part(@ 앞부분)로 들어옴
+ *     (예: bnm0218@icloud.com → name "bnm0218")
+ *
+ * 카카오는 한글 실명, 이메일 가입은 사용자가 직접 입력한 이름이라
+ * 위 두 패턴(해시 / 이메일 local-part 일치)에 해당하지 않는다.
+ * → 둘 중 하나라도 해당하면 이름/직군 설정 바텀시트를 띄운다.
+ */
+export const useAppleProfileSetup = () => {
+	const { data: memberResponse } = useQuery(getMyMemberInfoQuery);
+	const memberName = memberResponse?.data.name ?? '';
+	const memberEmail = memberResponse?.data.email ?? '';
+
+	const { data: hashValidation } = useQuery(getNameHashTypeValidationQuery(memberName));
+
+	// 이름이 이메일 local-part 와 동일 → Apple 자동 생성 이름으로 간주
+	const emailLocalPart = memberEmail.split('@')[0];
+	const isNameFromEmail = emailLocalPart.length > 0 && memberName === emailLocalPart;
+	// 이름이 해시(id) 형식 → 이메일 가리기 가입자
+	const isHashName = hashValidation?.data.isHashType === true;
+
+	const isSetupRequired = memberName.length > 0 && (isHashName || isNameFromEmail);
+
+	return {
+		isSetupRequired,
+		memberName,
+		memberEmail,
+	};
+};

--- a/apps/client/app/(home)/page.tsx
+++ b/apps/client/app/(home)/page.tsx
@@ -3,6 +3,7 @@ import { GAPageTracker } from '@dpm-core/shared';
 import { SafeAreaAppLayout } from '@/components/app-layout';
 import { BottomTabBar } from '@/components/bottom-tab-bar';
 
+import { AppleProfileSetupSheet } from './_components/apple-profile-setup-sheet';
 import { HomeCheckAttendanceBanner } from './_components/home-attendance-banner';
 import { HomeBannerList } from './_components/home-banner-list';
 import { HomeHeader } from './_components/home-header';
@@ -19,6 +20,7 @@ export default function HomePage() {
 				<UserActionList />
 			</main>
 			<BottomTabBar />
+			<AppleProfileSetupSheet />
 		</SafeAreaAppLayout>
 	);
 }

--- a/apps/client/remotes/mutations/member.ts
+++ b/apps/client/remotes/mutations/member.ts
@@ -1,6 +1,6 @@
 import { type MutationOptions, mutationOptions } from '@tanstack/react-query';
 import type { HTTPError } from 'ky';
-import { type ApiErrorReponse, member } from '@dpm-core/api';
+import { type ApiErrorReponse, type AppleMemberProfileUpdateRequest, member } from '@dpm-core/api';
 
 type WithdrawMutationOptions = MutationOptions;
 
@@ -30,5 +30,20 @@ export const approveWhitelistMutationOptions = (options: ApproveWhitelistOptions
 	mutationOptions({
 		mutationKey: ['whitelist'],
 		mutationFn: (params: ApproveWhitelistParams) => member.approveWhitelistForSignup(params),
+		...options,
+	});
+
+type UpdateAppleProfileOptions = MutationOptions<
+	unknown,
+	HTTPError<ApiErrorReponse>,
+	AppleMemberProfileUpdateRequest,
+	unknown
+>;
+
+/** Apple 로그인 멤버 프로필(이름/직군) 수정 */
+export const updateAppleProfileMutationOptions = (options?: UpdateAppleProfileOptions) =>
+	mutationOptions({
+		mutationKey: ['apple-profile-update'],
+		mutationFn: (params: AppleMemberProfileUpdateRequest) => member.updateAppleProfile(params),
 		...options,
 	});

--- a/apps/client/remotes/queries/member.ts
+++ b/apps/client/remotes/queries/member.ts
@@ -9,3 +9,26 @@ export const getMyMemberInfoQuery = queryOptions({
 	retry: false,
 	refetchInterval: false,
 });
+
+/** Apple 로그인 숨김 이메일 조회 */
+export const getAppleHiddenEmailQuery = queryOptions({
+	queryKey: ['apple-hidden-email'],
+	queryFn: () => {
+		return member.getAppleHiddenEmail();
+	},
+	retry: false,
+	refetchInterval: false,
+});
+
+/** 멤버 이름이 식별 불가능한 해시(id) 형식인지 검증 */
+export const getNameHashTypeValidationQuery = (name: string) =>
+	queryOptions({
+		queryKey: ['name-hash-type-validation', name],
+		queryFn: () => {
+			return member.validateNameHashType({ name });
+		},
+		enabled: name.length > 0,
+		staleTime: Number.POSITIVE_INFINITY,
+		retry: false,
+		refetchInterval: false,
+	});

--- a/packages/api/src/member/remote.ts
+++ b/packages/api/src/member/remote.ts
@@ -1,10 +1,14 @@
 import { http } from '../http';
 import type {
+	AppleHiddenEmailResponse,
+	AppleMemberProfileUpdateRequest,
 	ApproveWhitelistForSignupRequest,
 	ApproveWhitelistRequest,
 	ApproveWhitelistResponse,
 	InitCohortMemberParams,
 	Member,
+	MemberNameHashValidationRequest,
+	MemberNameHashValidationResponse,
 	MemberRoleListResponse,
 	MemberRoleResponse,
 	MembersOverviewResponse,
@@ -99,6 +103,31 @@ export const member = {
 	/** DELETE /v1/members/{memberId}/hard-delete - 멤버 하드 삭제 */
 	hardDeleteMember: async (memberId: number) => {
 		const res = await http.delete(`v1/members/${memberId}/hard-delete`);
+		return res;
+	},
+
+	/** GET /v1/members/apple/hidden-email - Apple 로그인 숨김 이메일 멤버 조회 */
+	getAppleHiddenEmail: async () => {
+		const res = await http.get<AppleHiddenEmailResponse>('v1/members/apple/hidden-email');
+		return res;
+	},
+
+	/** POST /v1/members/apple/profile - Apple 로그인 멤버 프로필(이름/직군) 수정 */
+	updateAppleProfile: async (params: AppleMemberProfileUpdateRequest) => {
+		const res = await http.post('v1/members/apple/profile', {
+			json: params,
+		});
+		return res;
+	},
+
+	/** POST /v1/members/name/hash-type/validation - 멤버 이름 해시(id) 형식 검증 */
+	validateNameHashType: async (params: MemberNameHashValidationRequest) => {
+		const res = await http.post<MemberNameHashValidationResponse>(
+			'v1/members/name/hash-type/validation',
+			{
+				json: params,
+			},
+		);
 		return res;
 	},
 };

--- a/packages/api/src/member/types.ts
+++ b/packages/api/src/member/types.ts
@@ -89,6 +89,37 @@ export interface InitCohortMemberParams {
 	memberId: number;
 }
 
+/**
+ * GET /v1/members/apple/hidden-email - Apple 로그인 숨김 이메일 멤버 조회
+ * 실제 응답은 `{ members: [...] }` 형태 (실 토큰 호출로 확인). 숨김 이메일 미사용 멤버는 빈 배열.
+ * NOTE: members 원소 구조는 빈 배열만 관측되어 미확정. 현재 프로필 설정 트리거에는 사용하지 않음.
+ */
+export interface AppleHiddenEmailResponse {
+	members: unknown[];
+}
+
+/**
+ * POST /v1/members/apple/profile - Apple 로그인 멤버 프로필(이름/파트) 수정
+ * Apple 초기 가입자의 이름이 식별 불가능한 id 값으로 들어오는 경우, 이름과 직군을 수정한다.
+ */
+export interface AppleMemberProfileUpdateRequest {
+	name: string;
+	part: Part;
+}
+
+/** POST /v1/members/name/hash-type/validation - 멤버 이름 해시 형식 검증 요청 */
+export interface MemberNameHashValidationRequest {
+	name: string;
+}
+
+/**
+ * POST /v1/members/name/hash-type/validation 응답
+ * isHashType === true 이면 이름이 식별 불가능한 해시(id) 형식임을 의미한다.
+ */
+export interface MemberNameHashValidationResponse {
+	isHashType: boolean;
+}
+
 /** GET /v1/roles/members/{memberId} - 멤버 역할 조회 */
 export interface MemberRoleResponse {
 	memberId: number;


### PR DESCRIPTION
## 개요
Apple 로그인 초기 가입자는 이름을 입력하지 않으면 `name`이 자동 생성값(이메일 local-part 또는 해시)으로 들어와 운영진/멤버 식별이 어렵습니다. 홈(`/`) 진입 시 이름/직군 설정 바텀시트를 노출해 프로필을 입력받습니다.

## 변경 사항
- **API 연동** (`packages/api/src/member`)
  - `GET /v1/members/apple/hidden-email`
  - `POST /v1/members/apple/profile` (이름/직군 저장)
  - `POST /v1/members/name/hash-type/validation` (이름 해시 형식 검증)
- **바텀시트** (`app/(home)/_components`, `_hooks`)
  - 노출 조건: `name === 이메일 @앞부분 || isHashType` → 카카오/이메일 가입자는 제외
  - 세로 라디오 파트 선택(Android/IOS/Web/Server/Design), 저장/취소 액션

## 검증
- 실제 토큰으로 백엔드 응답 확인 + 실 브라우저(Playwright) 모킹으로 노출/제출 시나리오 5/5 통과
- Biome·타입체크 클린

## 참고 / 후속
- `GET /apple/hidden-email` 응답은 `{ members: [] }` 형태로 확인되어 현재 트리거엔 미사용
- 보다 정확한 식별을 위해 `GET /v1/members/me`에 `provider`(또는 `needsAppleProfileSetup`) 필드 추가 시 `provider==='APPLE'`로 좁힐 수 있음

🤖 Generated with [Claude Code](https://claude.com/claude-code)