### PR TITLE
feat: Apple 프로필 설정 바텀시트 노출 시 안내 토스트 추가

### DIFF
--- a/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
+++ b/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
@@ -40,9 +40,11 @@ export const AppleProfileSetupSheet = () => {
 	const [part, setPart] = useState<Part | null>(null);
 
 	// 설정이 필요해지면 자동으로 바텀시트를 연다.
+	// 사용자가 바텀시트가 왜 떴는지 헷갈리지 않도록 안내 토스트를 함께 노출한다.
 	useEffect(() => {
 		if (isSetupRequired) {
 			setIsOpen(true);
+			toast.info('원활한 활동을 위해 이름과 직군 설정이 필요해요.');
 		}
 	}, [isSetupRequired]);
 


### PR DESCRIPTION
## 배경

Apple 초기 가입자에게 이름/직군 설정 바텀시트(#277)가 홈 진입 시 자동으로 노출되는데, 사용자들이 **왜 갑자기 이 시트가 뜨는지** 헷갈려하는 문제가 있었습니다.

## 변경 사항

바텀시트가 자동으로 열릴 때 안내 토스트를 함께 노출합니다.

```tsx
useEffect(() => {
    if (isSetupRequired) {
        setIsOpen(true);
        toast.info('원활한 활동을 위해 이름과 직군 설정이 필요해요.');
    }
}, [isSetupRequired]);
```

- `isSetupRequired`가 `false → true`로 전환될 때 한 번만 노출됩니다.
- 공유 패키지의 기존 `toast.info`(아이콘 없는 안내용 토스트)를 사용했습니다.

## 참고

- 문구는 추후 기획/디자인 협의에 따라 조정 가능합니다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 프로필 설정이 필요한 경우, 설정 화면이 열릴 때 안내 토스트도 함께 표시되도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->