### PR TITLE
[main] fix: Apple 프로필 바텀시트 키보드 노출 시 저장/취소 버튼 숨김 및 레이아웃 대응

### DIFF
--- a/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
+++ b/apps/client/app/(home)/_components/apple-profile-setup-sheet.tsx
@@ -38,6 +38,45 @@ export const AppleProfileSetupSheet = () => {
 	const [isOpen, setIsOpen] = useState(false);
 	const [name, setName] = useState('');
 	const [part, setPart] = useState<Part | null>(null);
+	// 모바일에서 키보드가 올라오면 저장/취소 버튼이 키보드에 밀려 어색하게 겹쳐 보이고,
+	// 콘텐츠(제목+이름+파트)가 키보드 위 공간보다 커서 상단(입력창)이 잘리거나 가려진다.
+	// → 키보드가 뜨면 버튼을 숨기고, 드로어를 키보드 위 가용 공간에 꽉 채운 뒤 내부 스크롤로
+	//   포커스된 입력창이 항상 보이게 한다.
+	// 포커스(onFocus/onBlur)는 iOS에서 Vaul과 타이밍이 꼬여 불안정하므로 visualViewport 로 직접 감지한다.
+	const [keyboardHeight, setKeyboardHeight] = useState(0);
+	// 키보드 위로 확보되는 가용 높이(=visualViewport 높이).
+	const [viewportHeight, setViewportHeight] = useState(0);
+	// 브라우저 UI 변동으로 인한 오탐을 피하기 위해 임계값(150px)을 둔다.
+	const isKeyboardOpen = keyboardHeight > 150;
+
+	useEffect(() => {
+		const viewport = window.visualViewport;
+		if (!viewport) return;
+
+		const handleViewportResize = () => {
+			// 키보드가 올라오면 visualViewport 높이가 레이아웃 뷰포트보다 크게 줄어든다.
+			setKeyboardHeight(Math.max(0, window.innerHeight - viewport.height));
+			setViewportHeight(viewport.height);
+		};
+
+		viewport.addEventListener('resize', handleViewportResize);
+		handleViewportResize();
+
+		return () => viewport.removeEventListener('resize', handleViewportResize);
+	}, []);
+
+	// iOS Safari는 인풋 포커스 시 문서를 간헐적으로 스크롤해, position:fixed 인 드로어까지
+	// 시각적으로 위로 밀어버린다(입력창이 잘리고 키보드와 시트 사이 빈 공간 발생).
+	// 키보드가 떠 있는 동안 window 스크롤을 상단에 고정해 이 밀림을 막는다.
+	useEffect(() => {
+		if (!isKeyboardOpen) return;
+
+		const lockScrollToTop = () => window.scrollTo(0, 0);
+		lockScrollToTop();
+		window.addEventListener('scroll', lockScrollToTop);
+
+		return () => window.removeEventListener('scroll', lockScrollToTop);
+	}, [isKeyboardOpen]);
 
 	// 설정이 필요해지면 자동으로 바텀시트를 연다.
 	// 사용자가 바텀시트가 왜 떴는지 헷갈리지 않도록 안내 토스트를 함께 노출한다.
@@ -80,10 +119,26 @@ export const AppleProfileSetupSheet = () => {
 	};
 
 	return (
-		<Drawer open={isOpen} onOpenChange={setIsOpen} dismissible={false} container={ref.current}>
+		<Drawer
+			open={isOpen}
+			onOpenChange={setIsOpen}
+			dismissible={false}
+			container={ref.current}
+			// Vaul 기본 키보드 리포지셔닝은 콘텐츠가 클 때 드로어를 과하게 밀어올려 입력창이 잘리므로 끄고,
+			// 아래에서 드로어를 키보드 위 공간에 직접 맞춘다.
+			repositionInputs={false}
+		>
 			<DrawerContent
-				className="mx-auto pb-safe-area"
-				style={{ maxWidth: ref.current?.clientWidth ?? 'auto' }}
+				className={`mx-auto pb-safe-area ${isKeyboardOpen ? 'overflow-y-auto' : ''}`}
+				style={{
+					maxWidth: ref.current?.clientWidth ?? 'auto',
+					// 키보드가 떠 있는 동안: 드로어 바닥을 키보드 바로 위에 두고(bottom),
+					// 높이를 키보드 위 가용 공간으로 고정해(height) 꽉 채운다. 넘치는 내용은 내부 스크롤되며
+					// 포커스된 입력창은 브라우저가 자동으로 스크롤해 보여준다.
+					...(isKeyboardOpen
+						? { bottom: keyboardHeight, height: viewportHeight, maxHeight: viewportHeight }
+						: {}),
+				}}
 			>
 				<DrawerHeader showCloseButton={false}>
 					<DrawerTitle className="font-semibold text-label-normal text-title2">
@@ -117,26 +172,28 @@ export const AppleProfileSetupSheet = () => {
 					</div>
 				</div>
 
-				<DrawerFooter>
-					<Button
-						variant="secondary"
-						size="full"
-						className="h-14 rounded-lg"
-						onClick={handleSubmit}
-						disabled={!isValid || isPending}
-					>
-						{isPending ? '저장 중...' : '저장'}
-					</Button>
-					<Button
-						variant="assistive"
-						size="full"
-						className="h-14 rounded-lg"
-						onClick={handleCancel}
-						disabled={isPending}
-					>
-						취소
-					</Button>
-				</DrawerFooter>
+				{!isKeyboardOpen && (
+					<DrawerFooter>
+						<Button
+							variant="secondary"
+							size="full"
+							className="h-14 rounded-lg"
+							onClick={handleSubmit}
+							disabled={!isValid || isPending}
+						>
+							{isPending ? '저장 중...' : '저장'}
+						</Button>
+						<Button
+							variant="assistive"
+							size="full"
+							className="h-14 rounded-lg"
+							onClick={handleCancel}
+							disabled={isPending}
+						>
+							취소
+						</Button>
+					</DrawerFooter>
+				)}
 			</DrawerContent>
 		</Drawer>
 	);


### PR DESCRIPTION
## 📌 개요

Apple 초기 가입자 프로필 설정 바텀시트에서 **이름 입력 시 키보드가 올라오면** 저장/취소 버튼이 키보드에 밀려 화면 중앙에 겹쳐 보이고, 콘텐츠가 키보드 위 공간보다 커서 **입력창이 잘리거나 가려지는** 문제를 해결합니다.

## 🐛 문제

- 키보드가 올라오면 `저장`/`취소` 버튼이 키보드 위로 밀려 본문과 겹쳐 보임
- 시트 콘텐츠(제목+이름+파트 5개)가 키보드 위 가용 공간보다 커서, 상단 입력창이 화면 밖으로 잘리거나 키보드에 가려짐
- iOS Safari가 인풋 포커스 시 문서를 스크롤해 배경(로고 등)까지 밀림 → **간헐적으로** 레이아웃이 깨짐

## ✅ 변경 사항

- `visualViewport`로 키보드 노출 여부/높이를 직접 감지 (`onFocus/onBlur`는 iOS에서 Vaul과 타이밍이 꼬여 불안정)
- 키보드가 뜨면 **저장/취소 버튼(`DrawerFooter`) 숨김**
- `repositionInputs={false}` + 드로어를 **키보드 위 가용 공간에 꽉 채우고**(`bottom`/`height`) **내부 스크롤**(`overflow-y-auto`) → 콘텐츠가 커도 입력창이 항상 보임
- iOS의 포커스 시 문서 스크롤로 `position:fixed` 드로어가 밀리는 간헐 버그를 **window 스크롤 락**으로 차단

## 🎬 데모

| 키보드 OFF (버튼 노출) | 키보드 ON (버튼 숨김 · 입력창 노출) |
|:---:|:---:|
| <img src="https://raw.githubusercontent.com/depromeet/dpm-core-client/assets/apple-profile-keyboard-demo/docs/pr-assets/apple-profile-keyboard/keyboard-off.png" width="300"> | <img src="https://raw.githubusercontent.com/depromeet/dpm-core-client/assets/apple-profile-keyboard-demo/docs/pr-assets/apple-profile-keyboard/keyboard-on.png" width="300"> |

▶️ **녹화 영상 (off → on → off):** [demo.mov 보기](https://raw.githubusercontent.com/depromeet/dpm-core-client/assets/apple-profile-keyboard-demo/docs/pr-assets/apple-profile-keyboard/demo.mov)

## 🧪 테스트

- iPhone 16e 시뮬레이터에서 키보드 on/off **5회 반복** 검증 — 간헐 버그 재현되지 않음
- `turbo type-check` 통과
